### PR TITLE
Add preserveDepthStencilContents parameter to SetRenderTargets

### DIFF
--- a/include/FNA3D.h
+++ b/include/FNA3D.h
@@ -775,13 +775,18 @@ FNA3DAPI void FNA3D_ApplyVertexBufferBindings(
  * numRenderTargets:	The size of the renderTargets array (can be 0).
  * depthStencilBuffer:	The depth/stencil renderbuffer (can be NULL).
  * depthFormat:		The format of the depth/stencil renderbuffer.
+ * preserveDepthStencilContents:
+ * 			Set this to 1 to store the depth/stencil contents
+ * 			for future use. Most of the time you'll want to
+ * 			keep this at 0 to not waste GPU bandwidth.
  */
 FNA3DAPI void FNA3D_SetRenderTargets(
 	FNA3D_Device *device,
 	FNA3D_RenderTargetBinding *renderTargets,
 	int32_t numRenderTargets,
 	FNA3D_Renderbuffer *depthStencilBuffer,
-	FNA3D_DepthFormat depthFormat
+	FNA3D_DepthFormat depthFormat,
+	uint8_t preserveDepthStencilContents
 );
 
 /* After unsetting a render target, call this to resolve multisample targets or

--- a/src/FNA3D.c
+++ b/src/FNA3D.c
@@ -484,7 +484,8 @@ void FNA3D_SetRenderTargets(
 	FNA3D_RenderTargetBinding *renderTargets,
 	int32_t numRenderTargets,
 	FNA3D_Renderbuffer *depthStencilBuffer,
-	FNA3D_DepthFormat depthFormat
+	FNA3D_DepthFormat depthFormat,
+	uint8_t preserveDepthStencilContents
 ) {
 	if (device == NULL)
 	{
@@ -495,7 +496,8 @@ void FNA3D_SetRenderTargets(
 		renderTargets,
 		numRenderTargets,
 		depthStencilBuffer,
-		depthFormat
+		depthFormat,
+		preserveDepthStencilContents
 	);
 }
 

--- a/src/FNA3D_Driver.h
+++ b/src/FNA3D_Driver.h
@@ -359,7 +359,8 @@ struct FNA3D_Device
 		FNA3D_RenderTargetBinding *renderTargets,
 		int32_t numRenderTargets,
 		FNA3D_Renderbuffer *depthStencilBuffer,
-		FNA3D_DepthFormat depthFormat
+		FNA3D_DepthFormat depthFormat,
+		uint8_t preserveDepthStencilContents
 	);
 
 	void (*ResolveTarget)(

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -935,7 +935,8 @@ static void D3D11_SetRenderTargets(
 	FNA3D_RenderTargetBinding *renderTargets,
 	int32_t numRenderTargets,
 	FNA3D_Renderbuffer *depthStencilBuffer,
-	FNA3D_DepthFormat depthFormat
+	FNA3D_DepthFormat depthFormat,
+	uint8_t preserveDepthStencilContents
 );
 static void D3D11_GetTextureData2D(
 	FNA3D_Renderer *driverData,
@@ -1325,7 +1326,8 @@ static void D3D11_INTERNAL_BlitFramebuffer(D3D11Renderer *renderer, int32_t w, i
 		NULL,
 		0,
 		NULL,
-		FNA3D_DEPTHFORMAT_NONE
+		FNA3D_DEPTHFORMAT_NONE,
+		0
 	);
 
 	SDL_UnlockMutex(renderer->ctxLock);
@@ -2031,7 +2033,8 @@ static void D3D11_SetRenderTargets(
 	FNA3D_RenderTargetBinding *renderTargets,
 	int32_t numRenderTargets,
 	FNA3D_Renderbuffer *depthStencilBuffer,
-	FNA3D_DepthFormat depthFormat
+	FNA3D_DepthFormat depthFormat,
+	uint8_t preserveDepthStencilContents
 ) {
 	D3D11Renderer *renderer = (D3D11Renderer*) driverData;
 	D3D11Texture *tex;
@@ -2386,7 +2389,8 @@ static void D3D11_INTERNAL_CreateFramebuffer(
 		NULL,
 		0,
 		NULL,
-		FNA3D_DEPTHFORMAT_NONE
+		FNA3D_DEPTHFORMAT_NONE,
+		0
 	);
 
 	#undef BB

--- a/src/FNA3D_Driver_OpenGL.c
+++ b/src/FNA3D_Driver_OpenGL.c
@@ -2525,7 +2525,8 @@ static void OPENGL_SetRenderTargets(
 	FNA3D_RenderTargetBinding *renderTargets,
 	int32_t numRenderTargets,
 	FNA3D_Renderbuffer *depthStencilBuffer,
-	FNA3D_DepthFormat depthFormat
+	FNA3D_DepthFormat depthFormat,
+	uint8_t preserveDepthStencilContents
 ) {
 	OpenGLRenderer *renderer = (OpenGLRenderer*) driverData;
 	OpenGLRenderbuffer *rb = (OpenGLRenderbuffer*) depthStencilBuffer;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6805,7 +6805,8 @@ static void VULKAN_SetRenderTargets(
 	FNA3D_RenderTargetBinding *renderTargets,
 	int32_t numRenderTargets,
 	FNA3D_Renderbuffer *depthStencilBuffer,
-	FNA3D_DepthFormat depthFormat
+	FNA3D_DepthFormat depthFormat,
+	uint8_t preserveDepthStencilContents
 ) {
 	VulkanRenderer *renderer = (VulkanRenderer*) driverData;
 	VulkanColorBuffer *cb;

--- a/src/FNA3D_Driver_template.txt
+++ b/src/FNA3D_Driver_template.txt
@@ -436,7 +436,8 @@ static void TEMPLATE_SetRenderTargets(
 	FNA3D_RenderTargetBinding *renderTargets,
 	int32_t numRenderTargets,
 	FNA3D_Renderbuffer *depthStencilBuffer,
-	FNA3D_DepthFormat depthFormat
+	FNA3D_DepthFormat depthFormat,
+	uint8_t preserveDepthStencilContents
 ) {
 }
 


### PR DESCRIPTION
Only implemented this for Metal so far. Not sure about the formatting for the header comment since it's an usually long parameter name.