### PR TITLE
When creating a D3D11 debug device fails try creating a regular one

### DIFF
--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -4609,7 +4609,7 @@ try_create_device:
 	{
 		/* Creating a debug mode device will fail on some systems due to the necessary
 		 * debug infrastructure not being available. Remove the debug flag and retry. */
-		FNA3D_LogWarn("Creating device in debug mode failed with error %08X. Trying non-debug.");
+		FNA3D_LogWarn("Creating device in debug mode failed with error %08X. Trying non-debug.", res);
 		flags ^= D3D11_CREATE_DEVICE_DEBUG;
 		debugMode = 0;
 		goto try_create_device;

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -4611,7 +4611,7 @@ try_create_device:
 		 * debug infrastructure not being available. Remove the debug flag and retry. */
 		FNA3D_LogWarn("Creating device in debug mode failed with error %08X. Trying non-debug.");
 		flags ^= D3D11_CREATE_DEVICE_DEBUG;
-        debugMode = 0;
+		debugMode = 0;
 		goto try_create_device;
 	}
 


### PR DESCRIPTION
For users without the necessary debug bits on their machine, creating a D3D11 device with the debug flag on fails with a specific cryptic HRESULT. So this PR adds a mechanism where if we fail to create a device in debug mode we try making a non-debug one before finally giving up.