### PR TITLE
Vulkan Sampler Descriptor Optimization

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -2664,10 +2664,7 @@ static uint8_t VULKAN_INTERNAL_AllocateDescriptorSets(
 ) {
 	VkResult vulkanResult;
 	uint32_t i;
-	VkDescriptorSetAllocateInfo descriptorSetAllocateInfo =
-	{
-		VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO
-	};
+	VkDescriptorSetAllocateInfo descriptorSetAllocateInfo;
 	VkDescriptorSetLayout *descriptorSetLayouts = SDL_stack_alloc(VkDescriptorSetLayout, descriptorSetCount);
 
 	for (i = 0; i < descriptorSetCount; i += 1)

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6276,6 +6276,7 @@ static VkFramebuffer VULKAN_INTERNAL_FetchFramebuffer(
 	}
 
 	framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+	framebufferInfo.pNext = NULL;
 	framebufferInfo.flags = 0;
 	framebufferInfo.renderPass = renderPass;
 	framebufferInfo.attachmentCount = attachmentCount;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6913,6 +6913,7 @@ static void VULKAN_DestroyDevice(FNA3D_Device *device)
 			);
 		}
 
+		SDL_free(shaderResources->samplerDescriptorPools);
 		SDL_free(shaderResources->samplerBindingIndices);
 		SDL_free(shaderResources->inactiveDescriptorSets);
 		SDL_free(shaderResources->elements);
@@ -7045,6 +7046,7 @@ static void VULKAN_DestroyDevice(FNA3D_Device *device)
 	renderer->vkDestroyDevice(renderer->logicalDevice, NULL);
 	renderer->vkDestroyInstance(renderer->instance, NULL);
 
+	SDL_free(renderer->writeDescriptorSets);
 	SDL_free(renderer->shaderResourcesHashTable.elements);
 	SDL_free(renderer->renderPassArray.elements);
 	SDL_free(renderer->samplerStateArray.elements);

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -63,6 +63,7 @@ static PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr = NULL;
 #define PRIMITIVE_TYPES_COUNT 5
 
 #define STARTING_SAMPLER_DESCRIPTOR_POOL_SIZE 16
+#define DESCRIPTOR_SET_DEACTIVATE_FRAMES 10
 
 #define NULL_BUFFER (VkBuffer) 0
 #define NULL_DESC_SET (VkDescriptorSet) 0
@@ -3053,7 +3054,7 @@ static void ShaderResources_DeactivateUnusedDescriptorSets(
 	{
 		shaderResources->elements[i].inactiveFrameCount += 1;
 
-		if (shaderResources->elements[i].inactiveFrameCount + 1 > 10)
+		if (shaderResources->elements[i].inactiveFrameCount + 1 > DESCRIPTOR_SET_DEACTIVATE_FRAMES)
 		{
 			arr = &shaderResources->buckets[shaderResources->elements[i].key % NUM_DESCRIPTOR_SET_HASH_BUCKETS];
 

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3053,7 +3053,8 @@ static void ShaderResources_DeactivateUnusedDescriptorSets(
 	{
 		shaderResources->elements[i].inactiveFrameCount += 1;
 
-		if (shaderResources->elements[i].inactiveFrameCount + 1 > 10) {
+		if (shaderResources->elements[i].inactiveFrameCount + 1 > 10)
+		{
 			arr = &shaderResources->buckets[shaderResources->elements[i].key % NUM_DESCRIPTOR_SET_HASH_BUCKETS];
 
 			/* remove index from bucket */


### PR DESCRIPTION
This patch reduces the number of descriptor set fetches by returning descriptor set references immediately at draw call time.