### PR TITLE
Fix issue with mixing up the hash and bindingsIndex in D3D11_INTERNAL…

### DIFF
--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -807,7 +807,6 @@ static ID3D11InputLayout* D3D11_INTERNAL_FetchBindingsInputLayout(
 	/* We need the vertex shader... */
 	MOJOSHADER_d3d11GetBoundShaders(&vertexShader, &blah);
 
-
 	/* Can we just reuse an existing input layout? */
 	result = (ID3D11InputLayout*) PackedVertexBufferBindingsArray_Fetch(
 		renderer->inputLayoutCache,

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -4006,7 +4006,7 @@ static void D3D11_AddDisposeEffect(
 	FNA3D_Renderer *driverData,
 	FNA3D_Effect *effect
 ) {
-	int i;
+	int32_t i;
 
 	D3D11Renderer *renderer = (D3D11Renderer*) driverData;
 	MOJOSHADER_effect *effectData = ((D3D11Effect*) effect)->effect;

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -794,7 +794,7 @@ static ID3D11InputLayout* D3D11_INTERNAL_FetchBindingsInputLayout(
 	int32_t numBindings,
 	uint32_t *hash
 ) {
-	int32_t numElements, bufsize, i, j, k, usage, index, attribLoc, bytecodeLength;
+	int32_t numElements, bufsize, i, j, k, usage, index, attribLoc, bytecodeLength, bindingsIndex;
 	uint8_t attrUse[MOJOSHADER_USAGE_TOTAL][16];
 	FNA3D_VertexDeclaration vertexDeclaration;
 	FNA3D_VertexElement element;
@@ -807,7 +807,6 @@ static ID3D11InputLayout* D3D11_INTERNAL_FetchBindingsInputLayout(
 	/* We need the vertex shader... */
 	MOJOSHADER_d3d11GetBoundShaders(&vertexShader, &blah);
 
-	int32_t bindingsIndex;
 
 	/* Can we just reuse an existing input layout? */
 	result = (ID3D11InputLayout*) PackedVertexBufferBindingsArray_Fetch(
@@ -4008,6 +4007,8 @@ static void D3D11_AddDisposeEffect(
 	FNA3D_Renderer *driverData,
 	FNA3D_Effect *effect
 ) {
+	int i;
+
 	D3D11Renderer *renderer = (D3D11Renderer*) driverData;
 	MOJOSHADER_effect *effectData = ((D3D11Effect*) effect)->effect;
 
@@ -4022,8 +4023,8 @@ static void D3D11_AddDisposeEffect(
 		renderer->effectApplied = 1;
 	}
 
-	// invalidate all inputLayouts
-	for (int i = 0; i < renderer->inputLayoutCache.count; i += 1)
+	/* invalidate all inputLayouts */
+	for ( i = 0; i < renderer->inputLayoutCache.count; i += 1)
 	{
 		ID3D11InputLayout_Release(
 			(ID3D11InputLayout*)renderer->inputLayoutCache.elements[i].value

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -4007,7 +4007,6 @@ static void D3D11_AddDisposeEffect(
 	FNA3D_Effect *effect
 ) {
 	int32_t i;
-
 	D3D11Renderer *renderer = (D3D11Renderer*) driverData;
 	MOJOSHADER_effect *effectData = ((D3D11Effect*) effect)->effect;
 

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -4022,7 +4022,7 @@ static void D3D11_AddDisposeEffect(
 	}
 
 	/* invalidate all inputLayouts */
-	for ( i = 0; i < renderer->inputLayoutCache.count; i += 1)
+	for (i = 0; i < renderer->inputLayoutCache.count; i += 1)
 	{
 		ID3D11InputLayout_Release(
 			(ID3D11InputLayout*)renderer->inputLayoutCache.elements[i].value

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -7960,11 +7960,12 @@ static void VULKAN_ApplyVertexBufferBindings(
 	VulkanRenderer *renderer = (VulkanRenderer*) driverData;
 	MOJOSHADER_vkShader *vertexShader, *blah;
 	int32_t i, bindingsIndex;
+	uint32_t hash;
 	void* bindingsResult;
 	VulkanBuffer *vertexBuffer;
 	VulkanSubBuffer subbuf;
 	VkDeviceSize offset;
-
+	
 	/* Check VertexBufferBindings */
 	MOJOSHADER_vkGetBoundShaders(&vertexShader, &blah);
 	bindingsResult = PackedVertexBufferBindingsArray_Fetch(
@@ -7972,7 +7973,8 @@ static void VULKAN_ApplyVertexBufferBindings(
 		bindings,
 		numBindings,
 		vertexShader,
-		&bindingsIndex
+		&bindingsIndex,
+		&hash
 	);
 	if (bindingsResult == NULL)
 	{

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -7965,7 +7965,7 @@ static void VULKAN_ApplyVertexBufferBindings(
 	VulkanBuffer *vertexBuffer;
 	VulkanSubBuffer subbuf;
 	VkDeviceSize offset;
-	
+
 	/* Check VertexBufferBindings */
 	MOJOSHADER_vkGetBoundShaders(&vertexShader, &blah);
 	bindingsResult = PackedVertexBufferBindingsArray_Fetch(

--- a/src/FNA3D_PipelineCache.c
+++ b/src/FNA3D_PipelineCache.c
@@ -214,7 +214,8 @@ void* PackedVertexBufferBindingsArray_Fetch(
 	FNA3D_VertexBufferBinding *bindings,
 	int32_t numBindings,
 	void* vertexShader,
-	int32_t *outIndex
+	int32_t *outIndex,
+	uint32_t *outHash
 ) {
 	int32_t i;
 	PackedVertexBufferBindings other;
@@ -232,6 +233,7 @@ void* PackedVertexBufferBindingsArray_Fetch(
 	}
 
 	*outIndex = i;
+	*outHash = hash;
 	return result;
 }
 

--- a/src/FNA3D_PipelineCache.h
+++ b/src/FNA3D_PipelineCache.h
@@ -84,7 +84,8 @@ void* PackedVertexBufferBindingsArray_Fetch(
 	FNA3D_VertexBufferBinding *bindings,
 	int32_t numBindings,
 	void* vertexShader,
-	int32_t *outIndex
+	int32_t *outIndex,
+	uint32_t *outHash
 );
 void PackedVertexBufferBindingsArray_Insert(
 	PackedVertexBufferBindingsArray *arr,


### PR DESCRIPTION
…_FetchBindingsInputLayout

Fix issue with inputLayoutCache invalidation when effect gets deleted, pointer was getting recycled by malloc and causing assertion failures.