### PR TITLE
Clear on Load

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6513,15 +6513,15 @@ static void VULKAN_INTERNAL_BeginRenderPass(
 				clearValues[clearValueCount].color.float32[2] = renderer->clearColorValue.float32[2];
 				clearValues[clearValueCount].color.float32[3] = renderer->clearColorValue.float32[3];
 				clearValueCount += 1;
-			}
 
-			if (renderer->colorMultiSampleAttachments[i] != NULL)
-			{
-				clearValues[clearValueCount].color.float32[0] = renderer->clearColorValue.float32[0];
-				clearValues[clearValueCount].color.float32[1] = renderer->clearColorValue.float32[1];
-				clearValues[clearValueCount].color.float32[2] = renderer->clearColorValue.float32[2];
-				clearValues[clearValueCount].color.float32[3] = renderer->clearColorValue.float32[3];
-				clearValueCount += 1;
+				if (renderer->colorMultiSampleAttachments[i] != NULL)
+				{
+					clearValues[clearValueCount].color.float32[0] = renderer->clearColorValue.float32[0];
+					clearValues[clearValueCount].color.float32[1] = renderer->clearColorValue.float32[1];
+					clearValues[clearValueCount].color.float32[2] = renderer->clearColorValue.float32[2];
+					clearValues[clearValueCount].color.float32[3] = renderer->clearColorValue.float32[3];
+					clearValueCount += 1;
+				}
 			}
 		}
 	}

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -649,7 +649,7 @@ typedef struct VulkanCommand
 		struct
 		{
 			VkRenderPassBeginInfo beginInfo;
-			VkClearValue clearValues[MAX_RENDERTARGET_BINDINGS + 1];
+			VkClearValue clearValues[2 * MAX_RENDERTARGET_BINDINGS + 1];
 		} beginRenderPass;
 
 		struct
@@ -6456,7 +6456,7 @@ static void VULKAN_INTERNAL_BeginRenderPass(
 	VkFramebuffer framebuffer;
 	VkImageAspectFlags depthAspectFlags;
 	float blendConstants[4];
-	VkClearValue clearValues[MAX_RENDERTARGET_BINDINGS + 1];
+	VkClearValue clearValues[2 * MAX_RENDERTARGET_BINDINGS + 1];
 	uint32_t clearValueCount = 0;
 	VulkanCommand *setBlendConstantsCmd;
 	uint32_t i;


### PR DESCRIPTION
This patch defers clears to render pass loads when possible. This should speed up MVK in particular. This patch also lets us properly handle the case when we don't care about preserving contents.