### PR TITLE
Multiple Command Buffers Per Frame

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3438,6 +3438,12 @@ static void VULKAN_INTERNAL_SubmitCommands(
 		);
 	}
 
+	if (renderer->activeCommandBufferCount <= 1 && renderer->numActiveCommands == 0)
+	{
+		FNA3D_LogInfo("no commands recorded, bailing out");
+		return;
+	}
+
 	VULKAN_INTERNAL_EndCommandBuffer(renderer, 0, 0);
 
 	/* Reset descriptor set data */
@@ -3502,8 +3508,9 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	{
 		renderer->inactiveCommandBuffers[renderer->inactiveCommandBufferCount] = renderer->submittedCommandBuffers[i];
 		renderer->inactiveCommandBufferCount += 1;
-		renderer->submittedCommandBufferCount -= 1;
 	}
+
+	renderer->submittedCommandBufferCount = 0;
 
 	/* FIXME: need a mutex */
 	renderer->gpuIdle = 1;
@@ -3540,8 +3547,9 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	{
 		renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount] = renderer->activeCommandBuffers[i];
 		renderer->submittedCommandBufferCount += 1;
-		renderer->activeCommandBufferCount -= 1;
 	}
+
+	renderer->activeCommandBufferCount = 0;
 
 	/* Present, if applicable */
 	if (present)

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3436,7 +3436,6 @@ static void VULKAN_INTERNAL_SubmitCommands(
 			destinationRectangle,
 			swapChainImageIndex
 		);
-
 	}
 
 	VULKAN_INTERNAL_EndCommandBuffer(renderer, 0, 0);
@@ -3554,6 +3553,20 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	VULKAN_INTERNAL_PerformDeferredDestroys(renderer);
 	MOJOSHADER_vkEndFrame();
 
+	/* Reset the command buffers */
+	for (i = 0; i < renderer->submittedCommandBufferCount; i += 1)
+	{
+		result = renderer->vkResetCommandBuffer(
+			renderer->submittedCommandBuffers[i],
+			VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT
+		);
+
+		if (result != VK_SUCCESS)
+		{
+			LogVulkanResult("vkResetCommandBuffer", result);
+		}
+	}
+
 	/* Mark command buffers as inactive */
 	/* FIXME: this needs a mutex */
 	for (i = 0; i < renderer->submittedCommandBufferCount; i += 1)
@@ -3574,19 +3587,6 @@ static void VULKAN_INTERNAL_SubmitCommands(
 		}
 	}
 	renderer->numBuffersInUse = 0;
-
-	/* Reset the command buffers */
-	/* TODO: should probably reset these individually to not wreck other CBs */
-	result = renderer->vkResetCommandPool(
-		renderer->logicalDevice,
-		renderer->commandPool,
-		VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT
-	);
-
-	if (result != VK_SUCCESS)
-	{
-		LogVulkanResult("vkResetCommandPool", result);
-	}
 
 	VULKAN_INTERNAL_BeginCommandBuffer(renderer);
 

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6839,7 +6839,7 @@ static void VULKAN_DestroyDevice(FNA3D_Device *device)
 	VULKAN_INTERNAL_DestroyTexture(renderer, renderer->dummyFragTexture3D);
 	VULKAN_INTERNAL_DestroyTexture(renderer, renderer->dummyFragTextureCube);
 
-	/* We have to do this twice so the rotation happens correctly */
+	/* We have to do this again even though we flushed so the rotation happens correctly */
 	VULKAN_INTERNAL_PerformDeferredDestroys(renderer);
 
 	VULKAN_INTERNAL_DestroyTextureStagingBuffer(renderer);

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4472,7 +4472,7 @@ static void VULKAN_INTERNAL_SetBufferData(
 		VULKAN_INTERNAL_AllocateSubBuffer(renderer, vulkanBuffer);
 	}
 
-	if (SUBBUF.bound != -1)
+	if (vulkanBuffer->bound || vulkanBuffer->boundSubmitted)
 	{
 		if (options == FNA3D_SETDATAOPTIONS_NONE)
 		{

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3162,7 +3162,7 @@ static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer) {
 	beginInfo.pInheritanceInfo = NULL;
 
 	/* If we are out of unused command buffers, allocate some more */
-	if (renderer->inactiveCommandBuffers == 0)
+	if (renderer->inactiveCommandBufferCount == 0)
 	{
 		renderer->activeCommandBuffers = SDL_realloc(
 			renderer->activeCommandBuffers,

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3146,7 +3146,8 @@ static void VULKAN_INTERNAL_ResetDescriptorSetData(VulkanRenderer *renderer)
 
 /* Vulkan: Command Buffers */
 
-static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer) {
+static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer)
+{
 	VkCommandBufferAllocateInfo allocateInfo;
 	VkCommandBufferBeginInfo beginInfo;
 	VkResult result;
@@ -3212,7 +3213,6 @@ static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer) {
 	if (result != VK_SUCCESS)
 	{
 		LogVulkanResult("vkBeginCommandBuffer", result);
-		return;
 	}
 }
 
@@ -3252,7 +3252,8 @@ static void VULKAN_INTERNAL_EndCommandBuffer(
 	}
 }
 
-static void VULKAN_INTERNAL_SwapChainBlit(VulkanRenderer *renderer,
+static void VULKAN_INTERNAL_SwapChainBlit(
+	VulkanRenderer *renderer,
 	FNA3D_Rect *sourceRectangle,
 	FNA3D_Rect *destinationRectangle,
 	uint32_t swapChainImageIndex

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3446,7 +3446,7 @@ static void VULKAN_INTERNAL_SubmitCommands(
 
 	if (renderer->activeCommandBufferCount <= 1 && renderer->numActiveCommands == 0)
 	{
-		FNA3D_LogInfo("no commands recorded, bailing out");
+		/* No commands recorded, bailing out */
 		return;
 	}
 


### PR DESCRIPTION
This patch breaks up our monolithic command buffer into multiple command buffers for performance reasons and removes our pattern where we performed a bunch of command encoding right at the end of the frame. It also allows the next frame to begin recording commands while the GPU is working.