### PR TITLE
Vulkan Texture Memory Allocator

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -7293,6 +7293,24 @@ static void VULKAN_DestroyDevice(FNA3D_Device *device)
 		NULL
 	);
 
+	for (i = 0; i < renderer->textureAllocator->textureBufferCount; i += 1)
+	{
+		for (j = 0; j < renderer->textureAllocator->textureBuffers[i]->freeRegionCount; j += 1)
+		{
+			SDL_free(renderer->textureAllocator->textureBuffers[i]->freeRegions[j]);
+		}
+
+		renderer->vkFreeMemory(
+			renderer->logicalDevice,
+			renderer->textureAllocator->textureBuffers[i]->memory,
+			NULL
+		);
+
+		SDL_free(renderer->textureAllocator->textureBuffers[i]);
+	}
+
+	SDL_free(renderer->textureAllocator);
+
 	for (i = 0; i < PHYSICAL_BUFFER_MAX_COUNT; i += 1)
 	{
 		if (renderer->bufferAllocator->physicalBuffers[i] != NULL)

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4711,8 +4711,6 @@ static uint8_t VULKAN_INTERNAL_AllocateTextureMemory(
 
 		textureBuffer->size = renderer->textureAllocator->nextAllocationSize;
 		textureBuffer->dedicated = 0;
-
-		renderer->textureAllocator->nextAllocationSize *= 2;
 	}
 
 	textureBuffer->freeRegions = SDL_malloc(sizeof(VulkanFreeTextureRegion*));
@@ -9863,7 +9861,7 @@ static FNA3D_Device* VULKAN_CreateDevice(
 	);
 	renderer->textureAllocator->textureBuffers = NULL;
 	renderer->textureAllocator->textureBufferCount = 0;
-	renderer->textureAllocator->nextAllocationSize = 0;
+	renderer->textureAllocator->nextAllocationSize = 100000000; /* 100MB */
 
 	/*
 	 * Choose depth formats

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4751,8 +4751,6 @@ static void VULKAN_INTERNAL_NewFreeTextureRegion(
 	VkDeviceSize offset,
 	VkDeviceSize size
 ) {
-	uint32_t i = 0;
-
 	/* TODO: an improvement here could be to merge contiguous free regions */
 	textureBuffer->freeRegionCount += 1;
 	if (textureBuffer->freeRegionCount > textureBuffer->freeRegionCapacity)
@@ -4762,13 +4760,9 @@ static void VULKAN_INTERNAL_NewFreeTextureRegion(
 			textureBuffer->freeRegions,
 			sizeof(VulkanFreeTextureRegion*) * textureBuffer->freeRegionCapacity
 		);
-
-		for (i = textureBuffer->freeRegionCount - 1; i < textureBuffer->freeRegionCapacity; i += 1)
-		{
-			textureBuffer->freeRegions[i] = SDL_malloc(sizeof(VulkanFreeTextureRegion));
-		}
 	}
 
+	textureBuffer->freeRegions[textureBuffer->freeRegionCount - 1] = SDL_malloc(sizeof(VulkanFreeTextureRegion));
 	textureBuffer->freeRegions[textureBuffer->freeRegionCount - 1]->offset = offset;
 	textureBuffer->freeRegions[textureBuffer->freeRegionCount - 1]->size = size;
 }
@@ -4862,6 +4856,8 @@ static uint8_t VULKAN_INTERNAL_FindAvailableTextureMemory(
 				/* If we completely used the region, remove it */
 				if (region->size == 0)
 				{
+					SDL_free(textureBuffer->freeRegions[j]);
+
 					if (textureBuffer->freeRegionCount > 1)
 					{
 						textureBuffer->freeRegions[j] =


### PR DESCRIPTION
Previously, we performed one memory allocation per texture create. Now we allocate 100MB chunks of texture memory at a time and mark empty regions so we can parcel it out appropriately.