### PR TITLE
Vulkan: Unify buffer and texture allocation systems

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -2914,7 +2914,11 @@ static uint8_t VULKAN_INTERNAL_FindAvailableMemory(
 
 	/* No suitable free regions exist, allocate a new memory region */
 
-	if (requiredSize > allocator->nextAllocationSize)
+	if (dedicatedRequirements.prefersDedicatedAllocation || dedicatedRequirements.requiresDedicatedAllocation)
+	{
+		allocationSize = requiredSize;
+	}
+	else if (requiredSize > allocator->nextAllocationSize)
 	{
 		/* allocate a page of required size aligned to STARTING_ALLOCATION_SIZE increments */
 		allocationSize =

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4526,7 +4526,7 @@ static void VULKAN_INTERNAL_BufferMemoryBarrier(
 	memoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 	memoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 	memoryBarrier.buffer = subBuffer->buffer;
-	memoryBarrier.offset = subBuffer->offset;
+	memoryBarrier.offset = 0;
 	memoryBarrier.size = buffer->size;
 
 	prevAccess = subBuffer->resourceAccessType;


### PR DESCRIPTION
This patch lets us leverage our free memory region strategy that we used for texture memory to allocate buffer space. Now we use the same memory allocation system for both types of allocations. We can now properly reclaim buffer space when buffers are destroyed. This also means that we get proper memory alignment for buffers, and we no longer have to crash if we run out of buffer space, among other advantages.