### PR TITLE
Copy NONE buffer data instead of flush and stall

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -5172,6 +5172,9 @@ static void VULKAN_INTERNAL_SetBufferData(
 			/* We can copy the buffer directly with a command
 			 * instead of stalling and mapping
 			 */
+
+			VULKAN_INTERNAL_MaybeEndRenderPass(renderer, 1);
+
 			copy.size = SUBBUF->size;
 			copy.srcOffset = 0;
 			copy.dstOffset = 0;
@@ -5183,6 +5186,8 @@ static void VULKAN_INTERNAL_SetBufferData(
 				1,
 				&copy
 			));
+
+			renderer->needNewRenderPass = 1;
 		}
 		else if (options == FNA3D_SETDATAOPTIONS_DISCARD)
 		{
@@ -9302,7 +9307,11 @@ static FNA3D_Buffer* VULKAN_GenVertexBuffer(
 		(VulkanRenderer*) driverData,
 		sizeInBytes,
 		RESOURCE_ACCESS_VERTEX_BUFFER,
-		VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
+		(
+			VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
+			VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+			VK_BUFFER_USAGE_TRANSFER_DST_BIT
+		)
 	);
 }
 
@@ -9429,7 +9438,11 @@ static FNA3D_Buffer* VULKAN_GenIndexBuffer(
 		(VulkanRenderer*) driverData,
 		sizeInBytes,
 		RESOURCE_ACCESS_INDEX_BUFFER,
-		VK_BUFFER_USAGE_INDEX_BUFFER_BIT
+		(
+			VK_BUFFER_USAGE_INDEX_BUFFER_BIT |
+			VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+			VK_BUFFER_USAGE_TRANSFER_DST_BIT
+		)
 	);
 }
 

--- a/src/FNA3D_Driver_Vulkan_vkfuncs.h
+++ b/src/FNA3D_Driver_Vulkan_vkfuncs.h
@@ -86,6 +86,7 @@ VULKAN_DEVICE_FUNCTION(BaseVK, void, vkCmdBlitImage, (VkCommandBuffer commandBuf
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkCmdClearAttachments, (VkCommandBuffer commandBuffer, uint32_t attachmentCount, const VkClearAttachment *pAttachments, uint32_t rectCount, const VkClearRect *pRects))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkCmdClearColorImage, (VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout, const VkClearColorValue *pColor, uint32_t rangeCount, const VkImageSubresourceRange *pRanges))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkCmdClearDepthStencilImage, (VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout, const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount, const VkImageSubresourceRange *pRanges))
+VULKAN_DEVICE_FUNCTION(BaseVK, void, vkCmdCopyBuffer, (VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount, const VkBufferCopy *pRegions))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkCmdCopyBufferToImage, (VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount, const VkBufferImageCopy *pRegions))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkCmdCopyImageToBuffer, (VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkCmdDraw, (VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance))


### PR DESCRIPTION
Changes SetBufferData with NONE option to use a buffer copy command on a bound buffer instead of flushing commands and stalling. This is what DXVK does for D3D9. Additionally, our internal list of bound buffers now tracks VulkanSubBuffers instead of VulkanBuffers, since these map directly to used VkBuffers.