### PR TITLE
Vulkan: fix null free on freeing dedicated resource

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3015,7 +3015,6 @@ static void VULKAN_INTERNAL_DestroyBuffer(
 				NULL
 			);
 
-			SDL_free(buffer->subBuffers[i]->allocation->freeRegions[0]);
 			SDL_free(buffer->subBuffers[i]->allocation->freeRegions);
 			SDL_free(buffer->subBuffers[i]->allocation);
 		}
@@ -3061,7 +3060,6 @@ static void VULKAN_INTERNAL_DestroyTexture(
 			NULL
 		);
 
-		SDL_free(texture->allocation->freeRegions[0]);
 		SDL_free(texture->allocation->freeRegions);
 		SDL_free(texture->allocation);
 	}


### PR DESCRIPTION
The sole free region created by an allocation is consumed entirely by a dedicated alloc, so these frees crash the program.