### PR TITLE
Vulkan: Fix hang on suboptimal or out of date swapchain

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4245,6 +4245,12 @@ static void VULKAN_INTERNAL_SubmitCommands(
 					}
 				}
 
+				for (i = 0; i < renderer->activeCommandBufferCount; i += 1)
+				{
+					renderer->inactiveCommandBuffers[renderer->inactiveCommandBufferCount] = renderer->activeCommandBuffers[i];
+					renderer->inactiveCommandBufferCount += 1;
+				}
+
 				renderer->activeCommandBufferCount = 0;
 
 				return;


### PR DESCRIPTION
Prevents hangs on alt-tabbing. Also modifies out-of-date swapchain behavior to not loop infinitely. If we fail to acquire a swapchain image after recreating once we bail out of SubmitCommands and reset the active command buffers.