### PR TITLE
Vulkan: More well-behaved present behavior

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4426,10 +4426,10 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	/* Now that commands are totally done, check if we need new swapchain */
 	if (present)
 	{
-		if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR ||
+		if (	acquireResult == VK_ERROR_OUT_OF_DATE_KHR ||
 			acquireResult == VK_SUBOPTIMAL_KHR || 
 			presentResult == VK_ERROR_OUT_OF_DATE_KHR ||
-			presentResult == VK_SUBOPTIMAL_KHR)
+			presentResult == VK_SUBOPTIMAL_KHR	)
 		{
 			VULKAN_INTERNAL_RecreateSwapchain(renderer, 0);
 		}

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4184,7 +4184,7 @@ static void VULKAN_INTERNAL_SubmitCommands(
 ) {
 	VkSubmitInfo submitInfo;
 	uint32_t i, j;
-	VkResult result, presentResult = VK_SUCCESS;
+	VkResult result, acquireResult, presentResult = VK_SUCCESS;
 	uint8_t acquireSuccess = 0;
 	uint32_t swapChainImageIndex;
 
@@ -4208,7 +4208,7 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	if (present)
 	{
 		/* Begin next frame */
-		result = renderer->vkAcquireNextImageKHR(
+		acquireResult = renderer->vkAcquireNextImageKHR(
 			renderer->logicalDevice,
 			renderer->swapChain,
 			UINT64_MAX,
@@ -4217,7 +4217,7 @@ static void VULKAN_INTERNAL_SubmitCommands(
 			&swapChainImageIndex
 		);
 
-		if (result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR)
+		if (acquireResult == VK_SUCCESS || acquireResult == VK_SUBOPTIMAL_KHR)
 		{
 			VULKAN_INTERNAL_SwapChainBlit(
 				renderer,
@@ -4426,7 +4426,9 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	/* Now that commands are totally done, check if we need new swapchain */
 	if (present)
 	{
-		if (presentResult == VK_ERROR_OUT_OF_DATE_KHR ||
+		if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR ||
+			acquireResult == VK_SUBOPTIMAL_KHR || 
+			presentResult == VK_ERROR_OUT_OF_DATE_KHR ||
 			presentResult == VK_SUBOPTIMAL_KHR)
 		{
 			VULKAN_INTERNAL_RecreateSwapchain(renderer, 0);


### PR DESCRIPTION
NVIDIA throws KHR_ERROR on minimize and alt-tab, so our previous swapchain behavior was crashing. We were also bailing hard out of all draw work if we failed to acquire a swapchain image. What we now do is when KHR_ERROR comes back from AcquireSwapchain, we cancel presentation, but still submit the queued work and rotate references. RTs can render and objects get properly cleaned up even if we don't present. Then we attempt to recreate the swapchain after work is submitted.