### PR TITLE
Add cmake option to disable D3D11 backend.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(FNA3D C)
 
 # Options
 option(BUILD_SHARED_LIBS "Build shared library" ON)
+option(DISABLE_D3D11 "Disable D3D11 backend")
 
 # Version
 SET(LIB_MAJOR_VERSION "0")
@@ -63,7 +64,7 @@ else()
 	)
 endif()
 
-if(WIN32)
+if(WIN32 AND NOT DISABLE_D3D11)
 	add_definitions(
 		-DFNA3D_DRIVER_D3D11
 	)


### PR DESCRIPTION
The D3D11 backend doesn't currently work on Wine for multiple reasons, the most important of which is that Wine doesn't have an HLSL shader compiler. I'd like to update Wine Mono's shipped FNA to a version using FNA3D, and disabling the D3D11 backend is the simplest way to get it working.

I don't think HLSL could be used on any of the other backends, so the option disables that as well.