### PR TITLE
Vulkan: Fix double free on RT textures

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -9388,23 +9388,6 @@ static void VULKAN_AddDisposeRenderbuffer(
 	renderer->renderbuffersToDestroy[renderer->renderbuffersToDestroyCount] = vlkRenderBuffer;
 	renderer->renderbuffersToDestroyCount += 1;
 	SDL_UnlockMutex(renderer->disposeLock);
-
-	if (	vlkRenderBuffer->colorBuffer != NULL &&
-		vlkRenderBuffer->colorBuffer->multiSampleCount > 0	)
-	{
-		VULKAN_AddDisposeTexture(
-			driverData,
-			(FNA3D_Texture*) vlkRenderBuffer->colorBuffer->multiSampleTexture
-		);
-	}
-
-	if (vlkRenderBuffer->depthBuffer != NULL)
-	{
-		VULKAN_AddDisposeTexture(
-			driverData,
-			(FNA3D_Texture*) vlkRenderBuffer->depthBuffer->handle
-		);
-	}
 }
 
 /* Vertex Buffers */


### PR DESCRIPTION
I erroneously thought that RT disposal was not freeing the RT-owned textures. What actually happened was a typo was preventing the deferred RT disposal method from ever being called. This patch reverts the additional disposal.