### PR TITLE
Vulkan: Fix NO_OVERWRITE behavior

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -5200,20 +5200,23 @@ static void VULKAN_INTERNAL_SetBufferData(
 	#define CURIDX vulkanBuffer->currentSubBufferIndex
 	#define SUBBUF vulkanBuffer->subBuffers[CURIDX]
 
-	/* If buffer has not been bound this frame, set the first unbound index */
-	if (!vulkanBuffer->bound)
-	{
-		for (i = 0; i < vulkanBuffer->subBufferCount; i += 1)
-		{
-			if (vulkanBuffer->subBuffers[i]->bound == -1)
-			{
-				break;
-			}
-		}
-		CURIDX = i;
-	}
-
 	prevIndex = CURIDX;
+
+	if (options != FNA3D_SETDATAOPTIONS_NOOVERWRITE)
+	{
+		/* If buffer has not been bound this frame, set the first unbound index */
+		if (!vulkanBuffer->bound)
+		{
+			for (i = 0; i < vulkanBuffer->subBufferCount; i += 1)
+			{
+				if (vulkanBuffer->subBuffers[i]->bound == -1)
+				{
+					break;
+				}
+			}
+			CURIDX = i;
+		}
+	}
 
 	/*
 	 * If buffer was bound and options is NONE or DISCARD

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -1174,8 +1174,8 @@ typedef struct VulkanRenderer
 
 	uint32_t numVertexBindings;
 	FNA3D_VertexBufferBinding *vertexBindings;
-	VkBuffer ldVertexBuffers[MAX_BOUND_VERTEX_BUFFERS];
-	VkDeviceSize ldVertexBufferOffsets[MAX_BOUND_VERTEX_BUFFERS];
+	VkBuffer boundVertexBuffers[MAX_BOUND_VERTEX_BUFFERS];
+	VkDeviceSize boundVertexBufferOffsets[MAX_BOUND_VERTEX_BUFFERS];
 
 	/* Should be equal to swap chain count */
 	VkBuffer ldVertUniformBuffer;
@@ -1184,7 +1184,6 @@ typedef struct VulkanRenderer
 	VkDeviceSize ldFragUniformOffset;
 	VkDeviceSize ldVertUniformSize;
 	VkDeviceSize ldFragUniformSize;
-
 
 	int32_t stencilRef;
 
@@ -7811,8 +7810,8 @@ static void VULKAN_DrawInstancedPrimitives(
 			renderer->currentCommandBuffer,
 			0,
 			renderer->numVertexBindings,
-			renderer->ldVertexBuffers,
-			renderer->ldVertexBufferOffsets
+			renderer->boundVertexBuffers,
+			renderer->boundVertexBufferOffsets
 		));
 	}
 	/* FIXME: State shadowing for index buffers? -flibit */
@@ -7918,8 +7917,8 @@ static void VULKAN_DrawPrimitives(
 			renderer->currentCommandBuffer,
 			0,
 			renderer->numVertexBindings,
-			renderer->ldVertexBuffers,
-			renderer->ldVertexBufferOffsets
+			renderer->boundVertexBuffers,
+			renderer->boundVertexBufferOffsets
 		));
 	}
 
@@ -8325,12 +8324,13 @@ static void VULKAN_ApplyVertexBufferBindings(
 		];
 
 		offset =
-			(bindings[i].vertexOffset) *
+			bindings[i].vertexOffset *
 			bindings[i].vertexDeclaration.vertexStride
 		;
 
-		renderer->ldVertexBuffers[i] = subbuf->buffer;
-		renderer->ldVertexBufferOffsets[i] = offset;
+		renderer->boundVertexBuffers[i] = subbuf->buffer;
+		renderer->boundVertexBufferOffsets[i] = offset;
+
 		VULKAN_INTERNAL_MarkAsBound(renderer, vertexBuffer);
 	}
 }


### PR DESCRIPTION
We always search for unbound sub-buffers on SetBufferData, and the bound state only resets after work completes, so systems that relied on correct NO_OVERWRITE behavior had flickering. Now we only search for an unbound sub-buffer if NO_OVERWRITE is not set. We also had some unclear and redundant record keeping on bound vertex buffers so I fixed that too.