### PR TITLE
Vulkan: save and load pipeline cache

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -7372,15 +7372,6 @@ static void VULKAN_DestroyDevice(FNA3D_Device *device)
 
 	if (pipelineCacheResult == VK_SUCCESS)
 	{
-		pipelineCacheData = SDL_malloc(pipelineCacheSize);
-
-		renderer->vkGetPipelineCacheData(
-			renderer->logicalDevice,
-			renderer->pipelineCache,
-			&pipelineCacheSize,
-			pipelineCacheData
-		);
-
 		pipelineCacheFileName = SDL_GetHint("FNA3D_VULKAN_PIPELINE_CACHE_FILE_NAME");
 		if (pipelineCacheFileName == NULL)
 		{
@@ -7389,17 +7380,26 @@ static void VULKAN_DestroyDevice(FNA3D_Device *device)
 
 		pipelineCacheFile = SDL_RWFromFile(pipelineCacheFileName, "wb");
 
-		if (pipelineCacheFile == NULL)
+		if (pipelineCacheFile != NULL)
 		{
-			FNA3D_LogWarn("Error opening pipeline cache file for writing!");
+			pipelineCacheData = SDL_malloc(pipelineCacheSize);
+
+			renderer->vkGetPipelineCacheData(
+				renderer->logicalDevice,
+				renderer->pipelineCache,
+				&pipelineCacheSize,
+				pipelineCacheData
+			);
+
+			SDL_RWwrite(pipelineCacheFile, pipelineCacheData, sizeof(uint8_t), pipelineCacheSize);
+			SDL_RWclose(pipelineCacheFile);
+
+			SDL_free(pipelineCacheData);
 		}
 		else
 		{
-			SDL_RWwrite(pipelineCacheFile, pipelineCacheData, sizeof(uint8_t), pipelineCacheSize);
-			SDL_RWclose(pipelineCacheFile);
+			FNA3D_LogWarn("Could not open pipeline cache file for writing!");
 		}
-
-		SDL_free(pipelineCacheData);
 	}
 	else
 	{

--- a/src/FNA3D_Driver_Vulkan_vkfuncs.h
+++ b/src/FNA3D_Driver_Vulkan_vkfuncs.h
@@ -138,6 +138,7 @@ VULKAN_DEVICE_FUNCTION(BaseVK, void, vkFreeCommandBuffers, (VkDevice device, VkC
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkFreeMemory, (VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkGetBufferMemoryRequirements2KHR, (VkDevice device, const VkBufferMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkGetDeviceQueue, (VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue *pQueue))
+VULKAN_DEVICE_FUNCTION(BaseVK, void, vkGetPipelineCacheData, (VkDevice device, VkPipelineCache pipelineCache, size_t* pDataSize, void* pData))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkGetImageMemoryRequirements2KHR, (VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements))
 VULKAN_DEVICE_FUNCTION(BaseVK, VkResult, vkGetFenceStatus, (VkDevice device, VkFence fence))
 VULKAN_DEVICE_FUNCTION(BaseVK, VkResult, vkGetSwapchainImagesKHR, (VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount, VkImage *pSwapchainImages))

--- a/src/FNA3D_Driver_Vulkan_vkfuncs.h
+++ b/src/FNA3D_Driver_Vulkan_vkfuncs.h
@@ -138,7 +138,7 @@ VULKAN_DEVICE_FUNCTION(BaseVK, void, vkFreeCommandBuffers, (VkDevice device, VkC
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkFreeMemory, (VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkGetBufferMemoryRequirements2KHR, (VkDevice device, const VkBufferMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkGetDeviceQueue, (VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue *pQueue))
-VULKAN_DEVICE_FUNCTION(BaseVK, void, vkGetPipelineCacheData, (VkDevice device, VkPipelineCache pipelineCache, size_t* pDataSize, void* pData))
+VULKAN_DEVICE_FUNCTION(BaseVK, VkResult, vkGetPipelineCacheData, (VkDevice device, VkPipelineCache pipelineCache, size_t* pDataSize, void* pData))
 VULKAN_DEVICE_FUNCTION(BaseVK, void, vkGetImageMemoryRequirements2KHR, (VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements))
 VULKAN_DEVICE_FUNCTION(BaseVK, VkResult, vkGetFenceStatus, (VkDevice device, VkFence fence))
 VULKAN_DEVICE_FUNCTION(BaseVK, VkResult, vkGetSwapchainImagesKHR, (VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount, VkImage *pSwapchainImages))


### PR DESCRIPTION
We were initializing a pipeline cache, but it never had any data! Now we save the pipeline cache data to a file in DestroyDevice and load it in CreateDevice.