### PR TITLE
Vulkan: batch texture uploads

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4092,7 +4092,7 @@ static void VULKAN_INTERNAL_CopyToStagingBuffer(
 
 	VULKAN_INTERNAL_WaitForStagingTransfers(renderer);
 
-	if (	renderer->textureStagingBuffer->fastBuffer != NULL	&&
+	if (	renderer->textureStagingBuffer->fastBuffer != NULL &&
 		renderer->textureStagingBuffer->fastBufferOffset + uploadLength < renderer->textureStagingBuffer->fastBuffer->size	)
 	{
 		stagingSubBuffer = renderer->textureStagingBuffer->fastBuffer->subBuffers[0];

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3121,24 +3121,15 @@ static uint8_t VULKAN_INTERNAL_FindAvailableBufferMemory(
 		&dedicatedRequirements
 	};
 
+	requiredMemoryPropertyFlags =
+		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+		VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 	if (isDeviceLocal)
 	{
-		requiredMemoryPropertyFlags =
-			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-			VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-
-		ignoredMemoryPropertyFlags = 0;
+		requiredMemoryPropertyFlags |=
+			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 	}
-	else
-	{
-		requiredMemoryPropertyFlags =
-			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-			VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-
-		ignoredMemoryPropertyFlags = 0;
-	}
-
+	ignoredMemoryPropertyFlags = 0;
 	if (!VULKAN_INTERNAL_FindBufferMemoryRequirements(
 		renderer,
 		buffer,
@@ -4135,11 +4126,10 @@ static void VULKAN_INTERNAL_PrepareCopyFromStagingBuffer(
 	VkDeviceSize *pOffset,
 	void **pStagingBufferPointer
 ) {
-	if (
-		dataLength <= MAX_FAST_TEXTURE_STAGING_SIZE &&
+	if (	dataLength <= MAX_FAST_TEXTURE_STAGING_SIZE &&
 		renderer->textureStagingBuffer->fastBuffer != NULL &&
-		renderer->textureStagingBuffer->fastBufferOffset + dataLength > renderer->textureStagingBuffer->fastBuffer->size
-	) {
+		renderer->textureStagingBuffer->fastBufferOffset + dataLength > renderer->textureStagingBuffer->fastBuffer->size	)
+	{
 		*pStagingSubBuffer = renderer->textureStagingBuffer->fastBuffer->subBuffers[0];
 		*pOffset = renderer->textureStagingBuffer->fastBufferOffset;
 		*pStagingBufferPointer =

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -5341,6 +5341,19 @@ static uint8_t VULKAN_INTERNAL_AllocateSubBuffer(
 		&subBuffer->size
 	);
 
+	/* No BAR memory available, just try CPU memory */
+	if (buffer->isStaging && findMemoryResult == 2)
+	{
+		findMemoryResult = VULKAN_INTERNAL_FindAvailableBufferMemory(
+			renderer,
+			subBuffer->buffer,
+			0,
+			&subBuffer->allocation,
+			&subBuffer->offset,
+			&subBuffer->size
+		);
+	}
+
 	/* We're out of available memory */
 	if (findMemoryResult == 2)
 	{

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4013,7 +4013,7 @@ static void VULKAN_INTERNAL_CreateSlowStagingBuffer(
 		RESOURCE_ACCESS_MEMORY_TRANSFER_READ_WRITE,
 		VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
 		0,
-		2
+		1
 	);
 
 	if (renderer->textureStagingBuffer->slowBuffer == NULL)

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3987,6 +3987,10 @@ static void VULKAN_INTERNAL_ResetTextureStagingBuffer(
 		renderer->textureStagingBuffer->transferInProgress = 1;
 		renderer->textureStagingBuffer->pendingTransfer = 0;
 	}
+	else
+	{
+		renderer->textureStagingBuffer->transferInProgress = 0;
+	}
 }
 
 static void VULKAN_INTERNAL_CreateFastStagingBuffer(


### PR DESCRIPTION
By packing as many textures as we can into the staging buffer before flushing we can greatly reduce the number of sync points on texture upload.