### PR TITLE
Vulkan Defragmenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Release/
 .DS_Store
 xcuserdata/
 *.xcworkspace/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ Release/
 .DS_Store
 xcuserdata/
 *.xcworkspace/
-build/

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4274,10 +4274,9 @@ static void VULKAN_INTERNAL_RemoveViewFramebuffer(
 		}
 	}
 
-	renderer->vkDestroyImageView(
-		renderer->logicalDevice,
-		imageView,
-		NULL
+	VULKAN_INTERNAL_DestroyImageView(
+		renderer,
+		imageView
 	);
 }
 
@@ -4293,10 +4292,9 @@ static void VULKAN_INTERNAL_DestroyTexture(
 		return;
 	}
 
-	renderer->vkDestroyImageView(
-		renderer->logicalDevice,
-		texture->view,
-		NULL
+	VULKAN_INTERNAL_DestroyImageView(
+		renderer,
+		texture->view
 	);
 
 	if (texture->isRenderTarget)
@@ -4418,10 +4416,9 @@ static void VULKAN_INTERNAL_PerformDeferredDestroys(VulkanRenderer *renderer)
 
 	for (i = 0; i < renderer->defragmentedImageViewsToDestroyCount; i += 1)
 	{
-		renderer->vkDestroyImageView(
-			renderer->logicalDevice,
-			renderer->defragmentedImageViewsToDestroy[i],
-			NULL
+		VULKAN_INTERNAL_DestroyImageView(
+			renderer,
+			renderer->defragmentedImageViewsToDestroy[i]
 		);
 	}
 

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -2851,6 +2851,8 @@ static void VULKAN_INTERNAL_NewMemoryFreeRegion(
 
 			VULKAN_INTERNAL_RemoveMemoryFreeRegion(renderer, allocation->freeRegions[i]);
 			VULKAN_INTERNAL_NewMemoryFreeRegion(renderer, allocation, newOffset, newSize);
+
+			SDL_UnlockMutex(renderer->allocatorLock);
 			return;
 		}
 
@@ -2862,6 +2864,8 @@ static void VULKAN_INTERNAL_NewMemoryFreeRegion(
 
 			VULKAN_INTERNAL_RemoveMemoryFreeRegion(renderer, allocation->freeRegions[i]);
 			VULKAN_INTERNAL_NewMemoryFreeRegion(renderer, allocation, newOffset, newSize);
+
+			SDL_UnlockMutex(renderer->allocatorLock);
 			return;
 		}
 	}
@@ -3426,6 +3430,7 @@ static uint8_t VULKAN_INTERNAL_BindResourceMemory(
 		(renderer->deviceLocalHeapUsage + allocationSize > renderer->maxDeviceLocalHeapUsage)	)
 	{
 		/* we are oversubscribing device local memory */
+		SDL_UnlockMutex(renderer->allocatorLock);
 		return 2;
 	}
 

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -940,13 +940,13 @@ static inline void PipelineLayoutHashArray_Insert(
 
 typedef struct VulkanMemoryAllocation VulkanMemoryAllocation;
 
-typedef struct VulkanMemoryFreeRegion
+typedef struct VulkanMemoryFreeRegion /* FIXME: unify this with MemoryUsedRegion */
 {
 	VulkanMemoryAllocation *allocation;
 	VkDeviceSize offset;
 	VkDeviceSize size;
-	uint32_t allocationIndex;
-	uint32_t sortedIndex;
+	uint32_t allocationIndex; /* FIXME: keep track of this on the allocation */
+	uint32_t sortedIndex; /* FIXME: keep track of this on the sub-allocator */
 } VulkanMemoryFreeRegion;
 
 typedef struct VulkanMemoryUsedRegion

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -943,13 +943,13 @@ typedef struct VulkanBuffer VulkanBuffer;
 typedef struct VulkanSubBuffer VulkanSubBuffer;
 typedef struct VulkanTexture VulkanTexture;
 
-typedef struct VulkanMemoryFreeRegion /* FIXME: unify this with MemoryUsedRegion */
+typedef struct VulkanMemoryFreeRegion
 {
 	VulkanMemoryAllocation *allocation;
 	VkDeviceSize offset;
 	VkDeviceSize size;
-	uint32_t allocationIndex; /* FIXME: keep track of this on the allocation */
-	uint32_t sortedIndex; /* FIXME: keep track of this on the sub-allocator */
+	uint32_t allocationIndex;
+	uint32_t sortedIndex;
 } VulkanMemoryFreeRegion;
 
 typedef struct VulkanMemoryUsedRegion

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3803,7 +3803,6 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 	VkResult result;
 	uint32_t i, level;
 	VulkanResourceAccessType copyResourceAccessType = RESOURCE_ACCESS_NONE;
-	VulkanResourceAccessType originalSourceAccessType;
 
 	renderer->needDefrag = 0;
 
@@ -3871,8 +3870,6 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 					);
 					break;
 				}
-
-				originalSourceAccessType = currentRegion->vulkanSubBuffer->resourceAccessType;
 
 				VULKAN_INTERNAL_BufferMemoryBarrier(
 					renderer,
@@ -3980,8 +3977,6 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 				{
 					aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
 				}
-
-				originalSourceAccessType = currentRegion->vulkanTexture->resourceAccessType;
 
 				VULKAN_INTERNAL_ImageMemoryBarrier(
 					renderer,

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3314,7 +3314,7 @@ static uint8_t VULKAN_INTERNAL_BindResourceMemory(
 				memoryRequirements->memoryRequirements.alignment
 			);
 
-			usedRegion->isBuffer = buffer != NULL;
+			usedRegion->isBuffer = buffer != VK_NULL_HANDLE;
 
 			newRegionSize = region->size - ((alignedOffset - region->offset) + requiredSize);
 			newRegionOffset = alignedOffset + requiredSize;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3376,10 +3376,8 @@ static uint8_t VULKAN_INTERNAL_BindResourceMemory(
 	allocator = &renderer->memoryAllocator->subAllocators[memoryTypeIndex];
 	requiredSize = memoryRequirements->memoryRequirements.size;
 
-	if (
-		(buffer == VK_NULL_HANDLE && image == VK_NULL_HANDLE) ||
-		(buffer != VK_NULL_HANDLE && image != VK_NULL_HANDLE)
-	)
+	if (	(buffer == VK_NULL_HANDLE && image == VK_NULL_HANDLE) ||
+		(buffer != VK_NULL_HANDLE && image != VK_NULL_HANDLE)	)
 	{
 		FNA3D_LogError("BindResourceMemory must be given either a VulkanSubBuffer or a VulkanTexture");
 		return 0;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -8204,6 +8204,7 @@ static void VULKAN_INTERNAL_MaybeEndRenderPass(
 		RECORD_CMD(renderer->vkCmdEndRenderPass(renderer->currentCommandBuffer));
 
 		renderer->renderPassInProgress = 0;
+		renderer->needNewRenderPass = 1;
 		renderer->drawCallMadeThisPass = 0;
 
 		/* Unlocking long-term lock */

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -95,7 +95,6 @@ static const uint32_t deviceExtensionCount = SDL_arraysize(deviceExtensionNames)
 #define FAST_TEXTURE_STAGING_SIZE 64000000 /* 64MB */
 #define STARTING_SLOW_TEXTURE_STAGING_SIZE 16000000 /* 16MB */
 #define MAX_SLOW_TEXTURE_STAGING_SIZE 256000000 /* 256MB */
-#define DEVICE_LOCAL_HEAP_USAGE_FACTOR 0.8
 
 /* Should be equivalent to the number of values in FNA3D_PrimitiveType */
 #define PRIMITIVE_TYPES_COUNT 5
@@ -2479,6 +2478,8 @@ static uint8_t VULKAN_INTERNAL_DeterminePhysicalDevice(
 	uint32_t physicalDeviceCount, i, suitableIndex;
 	uint32_t queueFamilyIndex, suitableQueueFamilyIndex;
 	VkDeviceSize deviceLocalHeapSize;
+	const char *deviceLocalHeapUsageFactorStr;
+	float deviceLocalHeapUsageFactor = 1.0f;
 	uint8_t deviceRank, highestRank;
 
 	vulkanResult = renderer->vkEnumeratePhysicalDevices(
@@ -2595,7 +2596,13 @@ static uint8_t VULKAN_INTERNAL_DeterminePhysicalDevice(
 		}
 	}
 
-	renderer->maxDeviceLocalHeapUsage = deviceLocalHeapSize * DEVICE_LOCAL_HEAP_USAGE_FACTOR;
+	deviceLocalHeapUsageFactorStr = SDL_GetHint("FNA3D_VULKAN_DEVICE_LOCAL_HEAP_USAGE_FACTOR");
+	if (deviceLocalHeapUsageFactorStr != NULL)
+	{
+		deviceLocalHeapUsageFactor = SDL_max(0, SDL_min(1.0, SDL_atof(deviceLocalHeapUsageFactorStr)));
+	}
+
+	renderer->maxDeviceLocalHeapUsage = deviceLocalHeapSize * deviceLocalHeapUsageFactor;
 	renderer->deviceLocalHeapUsage = 0;
 
 	SDL_stack_free(physicalDevices);

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3894,8 +3894,8 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 							imageCopyRegions[level].srcSubresource.baseArrayLayer = 0;
 							imageCopyRegions[level].srcSubresource.layerCount = currentRegion->vulkanTexture->layerCount;
 							imageCopyRegions[level].srcSubresource.mipLevel = level;
-							imageCopyRegions[level].extent.width = currentRegion->vulkanTexture->dimensions.width;
-							imageCopyRegions[level].extent.height = currentRegion->vulkanTexture->dimensions.height;
+							imageCopyRegions[level].extent.width = currentRegion->vulkanTexture->dimensions.width >> level;
+							imageCopyRegions[level].extent.height = currentRegion->vulkanTexture->dimensions.height >> level;
 							imageCopyRegions[level].extent.depth = currentRegion->vulkanTexture->depth;
 							imageCopyRegions[level].dstOffset.x = 0;
 							imageCopyRegions[level].dstOffset.y = 0;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3016,7 +3016,8 @@ static uint8_t VULKAN_INTERNAL_FindAvailableMemory(
 		allocator->nextAllocationSize = SDL_min(allocator->nextAllocationSize * 2, MAX_ALLOCATION_SIZE);
 	}
 
-	if (isDeviceLocal && renderer->deviceLocalHeapUsage + allocationSize > renderer->maxDeviceLocalHeapUsage)
+	if (	isDeviceLocal &&
+		(renderer->deviceLocalHeapUsage + allocationSize > renderer->maxDeviceLocalHeapUsage)	)
 	{
 		/* we are oversubscribing device local memory */
 		return 2;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3474,7 +3474,7 @@ static uint8_t VULKAN_INTERNAL_BindMemoryForImage(
 	uint8_t isRenderTarget,
 	VulkanMemoryUsedRegion** usedRegion
 ) {
-	uint32_t bindResult = 0;
+	uint8_t bindResult = 0;
 	uint32_t memoryTypeIndex;
 	VkMemoryPropertyFlags requiredMemoryPropertyFlags;
 	VkMemoryPropertyFlags ignoredMemoryPropertyFlags;
@@ -3728,7 +3728,7 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 
 						VULKAN_INTERNAL_BufferMemoryBarrier(
 							renderer,
-							copyResourceAccessType,
+							RESOURCE_ACCESS_TRANSFER_WRITE,
 							copyBuffer,
 							&copyResourceAccessType
 						);
@@ -4576,7 +4576,7 @@ static uint8_t VULKAN_INTERNAL_AllocateSubBuffer(
 	VulkanSubBuffer *subBuffer = SDL_malloc(sizeof(VulkanSubBuffer));
 	VkBufferCreateInfo bufferCreateInfo;
 	VkResult vulkanResult;
-	uint32_t bindResult = 0;
+	uint8_t bindResult = 0;
 
 	subBuffer->parent = vulkanBuffer;
 
@@ -4775,13 +4775,17 @@ static void VULKAN_INTERNAL_WaitForStagingTransfers(
 	VulkanRenderer *renderer
 ) {
 	VkResult result;
+	VkFence fences[2];
 
 	if (renderer->textureStagingBuffer->transferInProgress)
 	{
+		fences[0] = renderer->inFlightFence;
+		fences[1] = renderer->defragFence;
+
 		result = renderer->vkWaitForFences(
 			renderer->logicalDevice,
-			1,
-			&renderer->inFlightFence,
+			2,
+			fences,
 			VK_TRUE,
 			UINT64_MAX
 		);
@@ -6038,7 +6042,7 @@ static void VULKAN_INTERNAL_FlushCommands(VulkanRenderer *renderer, uint8_t sync
 
 		result = renderer->vkWaitForFences(
 			renderer->logicalDevice,
-			1,
+			2,
 			fences,
 			VK_TRUE,
 			UINT64_MAX
@@ -6554,7 +6558,7 @@ static uint8_t VULKAN_INTERNAL_CreateTexture(
 	VulkanTexture *texture
 ) {
 	VkResult result;
-	uint32_t bindResult = 0;
+	uint8_t bindResult = 0;
 	VkImageCreateInfo imageCreateInfo;
 	VkImageViewCreateInfo imageViewCreateInfo;
 	uint8_t layerCount = isCube ? 6 : 1;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3118,14 +3118,15 @@ static void VULKAN_INTERNAL_DeallocateMemory(
 
 	for (i = 0; i < allocation->freeRegionCount; i += 1)
 	{
-		SDL_free(allocation->freeRegions[i]);
+		VULKAN_INTERNAL_RemoveMemoryFreeRegion(
+			allocation->freeRegions[i]
+		);
 	}
 	SDL_free(allocation->freeRegions);
 
-	for (i = 0; i < allocation->usedRegionCount; i += 1)
-	{
-		SDL_free(allocation->usedRegions[i]);
-	}
+	/* no need to iterate used regions because deallocate
+	 * only happens when there are 0 used regions
+	 */
 	SDL_free(allocation->usedRegions);
 
 	renderer->vkFreeMemory(
@@ -3141,6 +3142,8 @@ static void VULKAN_INTERNAL_DeallocateMemory(
 	{
 		allocator->allocations[allocationIndex] = allocator->allocations[allocator->allocationCount - 1];
 	}
+
+	allocator->allocationCount -= 1;
 }
 
 static uint8_t VULKAN_INTERNAL_AllocateMemory(
@@ -4370,13 +4373,11 @@ static void VULKAN_INTERNAL_PerformDeferredDestroys(VulkanRenderer *renderer)
 		{
 			if (allocator->allocations[j]->usedRegionCount == 0)
 			{
-				/*
 				VULKAN_INTERNAL_DeallocateMemory(
 					renderer,
 					allocator,
 					j
 				);
-				*/
 			}
 		}
 	}

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -90,6 +90,7 @@ static const uint32_t deviceExtensionCount = SDL_arraysize(deviceExtensionNames)
 #define MAX_UNIFORM_DESCRIPTOR_SETS 1024
 #define COMMAND_LIMIT 100
 #define STARTING_ALLOCATION_SIZE 64000000 /* 64MB */
+#define ALLOCATION_INCREMENT 16000000 /* 16MB */
 #define MAX_ALLOCATION_SIZE 256000000 /* 256MB */
 #define FAST_TEXTURE_STAGING_SIZE 64000000 /* 64MB */
 #define STARTING_SLOW_TEXTURE_STAGING_SIZE 16000000 /* 16MB */
@@ -3457,14 +3458,13 @@ static uint8_t VULKAN_INTERNAL_BindResourceMemory(
 	}
 	else if (requiredSize > allocator->nextAllocationSize)
 	{
-		/* allocate a page of required size aligned to STARTING_ALLOCATION_SIZE increments */
+		/* allocate a page of required size aligned to ALLOCATION_INCREMENT increments */
 		allocationSize =
-			VULKAN_INTERNAL_NextHighestAlignment(requiredSize, STARTING_ALLOCATION_SIZE);
+			VULKAN_INTERNAL_NextHighestAlignment(requiredSize, ALLOCATION_INCREMENT);
 	}
 	else
 	{
 		allocationSize = allocator->nextAllocationSize;
-		allocator->nextAllocationSize = SDL_min(allocator->nextAllocationSize * 2, MAX_ALLOCATION_SIZE);
 	}
 
 	if (	isDeviceLocal &&

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -2599,7 +2599,11 @@ static uint8_t VULKAN_INTERNAL_DeterminePhysicalDevice(
 	deviceLocalHeapUsageFactorStr = SDL_GetHint("FNA3D_VULKAN_DEVICE_LOCAL_HEAP_USAGE_FACTOR");
 	if (deviceLocalHeapUsageFactorStr != NULL)
 	{
-		deviceLocalHeapUsageFactor = SDL_max(0, SDL_min(1.0, SDL_atof(deviceLocalHeapUsageFactorStr)));
+		double factor = SDL_atof(deviceLocalHeapUsageFactorStr);
+		if (factor > 0.0 && factor < 1.0)
+		{
+			deviceLocalHeapUsageFactor = factor;
+		}
 	}
 
 	renderer->maxDeviceLocalHeapUsage = deviceLocalHeapSize * deviceLocalHeapUsageFactor;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3805,9 +3805,6 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 	VulkanResourceAccessType copyResourceAccessType = RESOURCE_ACCESS_NONE;
 	VulkanResourceAccessType originalSourceAccessType;
 
-	uint32_t bufferCopyCount = 0;
-	uint32_t imageCopyCount = 0;
-
 	renderer->needDefrag = 0;
 
 	renderer->vkResetCommandBuffer(
@@ -3941,8 +3938,6 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 
 				renderer->bufferDefragInProgress = 1;
 				renderer->needDefrag = 1;
-
-				bufferCopyCount += 1;
 			}
 			else
 			{
@@ -4111,14 +4106,9 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 				newRegion->vulkanTexture->resourceAccessType = copyResourceAccessType;
 
 				renderer->needDefrag = 1;
-
-				imageCopyCount += 1;
 			}
 		}
 	}
-
-	FNA3D_LogInfo("Image copy count: %u", imageCopyCount);
-	FNA3D_LogInfo("Buffer copy count: %u", bufferCopyCount);
 
 	renderer->vkEndCommandBuffer(
 		renderer->defragCommandBuffer

--- a/src/FNA3D_Driver_Vulkan_vkfuncs.h
+++ b/src/FNA3D_Driver_Vulkan_vkfuncs.h
@@ -93,6 +93,8 @@ VULKAN_DEVICE_FUNCTION(void, vkCmdBlitImage, (VkCommandBuffer commandBuffer, VkI
 VULKAN_DEVICE_FUNCTION(void, vkCmdClearAttachments, (VkCommandBuffer commandBuffer, uint32_t attachmentCount, const VkClearAttachment *pAttachments, uint32_t rectCount, const VkClearRect *pRects))
 VULKAN_DEVICE_FUNCTION(void, vkCmdClearColorImage, (VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout, const VkClearColorValue *pColor, uint32_t rangeCount, const VkImageSubresourceRange *pRanges))
 VULKAN_DEVICE_FUNCTION(void, vkCmdClearDepthStencilImage, (VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout, const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount, const VkImageSubresourceRange *pRanges))
+VULKAN_DEVICE_FUNCTION(void, vkCmdCopyBuffer, (VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount, const VkBufferCopy *pRegions))
+VULKAN_DEVICE_FUNCTION(void, vkCmdCopyImage, (VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageCopy* pRegions))
 VULKAN_DEVICE_FUNCTION(void, vkCmdCopyBufferToImage, (VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount, const VkBufferImageCopy *pRegions))
 VULKAN_DEVICE_FUNCTION(void, vkCmdCopyImageToBuffer, (VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions))
 VULKAN_DEVICE_FUNCTION(void, vkCmdDraw, (VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance))


### PR DESCRIPTION
It's finally here! 

Every frame after commands are submitted, the system checks to see if any regions of memory are fragmented. If they are, we allocate a new block and queue up GPU-to-GPU copy commands of the resources in the fragmented block, which are added to a special command buffer that is submitted immediately. This way the copies are performed while the next frame is being built. The copies are performed sequentially into the new block, leaving no gaps. Once the next frame is submitted, we iterate over the resources that were copied and destroy them. If a block of memory is completely freed, we deallocate it.

All render targets are now allocated to dedicated memory blocks to prevent expensive copies and having to destroy and recreate a huge chain of resource dependencies.

We also now mark off partitions to include alignment offset regions to avoid tiny free regions created by alignments.

This is a very complex system and it's going to need a lot of testing, but I'm confident that this approach will reduce memory usage significantly.