### PR TITLE
Vulkan: Fix SetBufferData overwriting in-flight None and Discard submissions

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6818,7 +6818,8 @@ static void VULKAN_INTERNAL_SetBufferData(
 	 * If so, we start at sub-buffer 0 and increment the index until we find a sub-buffer that is unbound.
 	 * Otherwise we use the current sub-buffer index.
 	 */
-	if ((options != FNA3D_SETDATAOPTIONS_NOOVERWRITE && (vulkanBuffer->bound || vulkanBuffer->boundSubmitted)))
+	if (	options != FNA3D_SETDATAOPTIONS_NOOVERWRITE &&
+		(vulkanBuffer->bound || vulkanBuffer->boundSubmitted)	)
 	{
 		CURIDX = 0;
 		while (CURIDX < vulkanBuffer->subBufferCount && SUBBUF->bound != -1)

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6796,6 +6796,7 @@ static void VULKAN_INTERNAL_MarkAsBound(
 	renderer->numBuffersInUse += 1;
 }
 
+/* This function is EXTREMELY sensitive. Change this at your own peril. -thatcosmonaut */
 static void VULKAN_INTERNAL_SetBufferData(
 	FNA3D_Renderer *driverData,
 	FNA3D_Buffer *buffer,
@@ -6815,38 +6816,24 @@ static void VULKAN_INTERNAL_SetBufferData(
 
 	prevIndex = CURIDX;
 
-	if (options != FNA3D_SETDATAOPTIONS_NOOVERWRITE)
-	{
-		/* If buffer has not been bound this frame, set the first unbound index */
-		if (!vulkanBuffer->bound)
-		{
-			for (i = 0; i < vulkanBuffer->subBufferCount; i += 1)
-			{
-				if (vulkanBuffer->subBuffers[i]->bound == -1)
-				{
-					break;
-				}
-			}
-			CURIDX = i;
-		}
-	}
+	/* If NOOVERWRITE is set, we check if the buffer was bound and submitted on the previous frame.
+	 * If so, we increment the index until we find a sub-buffer that has not been bound.
+	 * Otherwise we use the current sub-buffer index.
 
-	/*
-	 * If buffer was bound and options is NONE or DISCARD
-	 * find the next available unbound sub-buffer
+	 * If NONE or DISCARD is set, we check if the buffer was bound either this frame or the previous frame.
+	 * If so, we increment the index until we find a sub-buffer that is unbound.
+	 * Otherwise we use the current sub-buffer index.
 	 */
-	if (vulkanBuffer->bound)
-	{
-		if (options == FNA3D_SETDATAOPTIONS_NONE || options == FNA3D_SETDATAOPTIONS_DISCARD)
+	if ((options == FNA3D_SETDATAOPTIONS_NOOVERWRITE && vulkanBuffer->boundSubmitted) ||
+		(options != FNA3D_SETDATAOPTIONS_NOOVERWRITE && (vulkanBuffer->bound || vulkanBuffer->boundSubmitted))
+	) {
+		while (CURIDX < vulkanBuffer->subBufferCount && SUBBUF->bound != -1)
 		{
-			while (CURIDX < vulkanBuffer->subBufferCount && SUBBUF->bound != -1)
-			{
-				CURIDX += 1;
-			}
+			CURIDX += 1;
 		}
 	}
 
-	/* Create a new SubBuffer if needed */
+	/* We are out of valid sub-buffers, so we have to create a new one */
 	if (CURIDX == vulkanBuffer->subBufferCount)
 	{
 		allocateResult = VULKAN_INTERNAL_AllocateSubBuffer(renderer, vulkanBuffer);
@@ -6863,6 +6850,7 @@ static void VULKAN_INTERNAL_SetBufferData(
 		}
 	}
 
+	/* If this is a defrag frame, wait for that to finish */
 	if (renderer->bufferDefragInProgress)
 	{
 		renderer->vkWaitForFences(
@@ -6877,7 +6865,7 @@ static void VULKAN_INTERNAL_SetBufferData(
 	}
 
 	/* If options is NONE and buffer was bound, copy the previous data into the new buffer */
-	if (options == FNA3D_SETDATAOPTIONS_NONE && prevIndex != CURIDX)
+	if (options == FNA3D_SETDATAOPTIONS_NONE && vulkanBuffer->bound)
 	{
 		SDL_memcpy(
 			SUBBUF->usedRegion->allocation->mapPointer + SUBBUF->usedRegion->resourceOffset,

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6809,7 +6809,6 @@ static void VULKAN_INTERNAL_SetBufferData(
 	VulkanBuffer *vulkanBuffer = (VulkanBuffer*) buffer;
 	uint32_t prevIndex;
 	uint8_t allocateResult;
-	uint32_t i;
 
 	#define CURIDX vulkanBuffer->currentSubBufferIndex
 	#define SUBBUF vulkanBuffer->subBuffers[CURIDX]

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6176,7 +6176,6 @@ static void VULKAN_INTERNAL_SubmitCommands(
 		{
 			renderer->buffersInUse[i]->bound = 0;
 			renderer->buffersInUse[i]->boundSubmitted = 1;
-			renderer->buffersInUse[i]->currentSubBufferIndex = 0;
 
 			renderer->submittedBuffers[i] = renderer->buffersInUse[i];
 			renderer->buffersInUse[i] = NULL;
@@ -6815,17 +6814,13 @@ static void VULKAN_INTERNAL_SetBufferData(
 
 	prevIndex = CURIDX;
 
-	/* If NOOVERWRITE is set, we check if the buffer was bound and submitted on the previous frame.
-	 * If so, we increment the index until we find a sub-buffer that has not been bound.
-	 * Otherwise we use the current sub-buffer index.
-
-	 * If NONE or DISCARD is set, we check if the buffer was bound either this frame or the previous frame.
-	 * If so, we increment the index until we find a sub-buffer that is unbound.
+	/* If NONE or DISCARD is set, we check if the buffer was bound either this frame or the previous frame.
+	 * If so, we start at sub-buffer 0 and increment the index until we find a sub-buffer that is unbound.
 	 * Otherwise we use the current sub-buffer index.
 	 */
-	if ((options == FNA3D_SETDATAOPTIONS_NOOVERWRITE && vulkanBuffer->boundSubmitted) ||
-		(options != FNA3D_SETDATAOPTIONS_NOOVERWRITE && (vulkanBuffer->bound || vulkanBuffer->boundSubmitted))
-	) {
+	if ((options != FNA3D_SETDATAOPTIONS_NOOVERWRITE && (vulkanBuffer->bound || vulkanBuffer->boundSubmitted)))
+	{
+		CURIDX = 0;
 		while (CURIDX < vulkanBuffer->subBufferCount && SUBBUF->bound != -1)
 		{
 			CURIDX += 1;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6795,7 +6795,7 @@ static void VULKAN_INTERNAL_MarkAsBound(
 	renderer->numBuffersInUse += 1;
 }
 
-/* This function is EXTREMELY sensitive. Change this at your own peril. -thatcosmonaut */
+/* This function is EXTREMELY sensitive. Change this at your own peril. -cosmonaut */
 static void VULKAN_INTERNAL_SetBufferData(
 	FNA3D_Renderer *driverData,
 	FNA3D_Buffer *buffer,

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6859,7 +6859,7 @@ static void VULKAN_INTERNAL_SetBufferData(
 	}
 
 	/* If options is NONE and buffer was bound, copy the previous data into the new buffer */
-	if (options == FNA3D_SETDATAOPTIONS_NONE && vulkanBuffer->bound)
+	if (options == FNA3D_SETDATAOPTIONS_NONE && prevIndex != CURIDX)
 	{
 		SDL_memcpy(
 			SUBBUF->usedRegion->allocation->mapPointer + SUBBUF->usedRegion->resourceOffset,


### PR DESCRIPTION
[`03d90b4`](https://github.com/FNA-XNA/FNA3D/commit/f54ebc2e68f509209d48e5eca374d14f6f707307) fixed an issue where the sub-buffer index was never reset, causing unbounded sub-buffer growth. Unfortunately, this also meant that `SetBufferData` was now actually capable of overwriting already-used sub-buffers. As a consequence, it was selecting sub-buffers that were still being used in rendering and overwriting their data.

The Vulkan renderer is unique in that we begin processing frames while the previously submitted frame is still rendering. This means that we need to be extra careful in how we select `SetBufferData` sub-buffers.

The process is now as follows:

If NOOVERWRITE is set, we assume the user knows what they're doing and copy using the current sub buffer index even if the buffer might be in-flight. This is actually XNA behavior!

If NONE or DISCARD is set, we check if the buffer was bound either this frame or the previous frame. If so, we increment the index until we find a sub-buffer that is unbound. Otherwise we use the current sub-buffer index.

If no valid sub-buffer was found, we allocate a new one.

If NONE is set and the buffer was bound this frame, we copy its data from the old sub-buffer to the next one.