### PR TITLE
Vulkan: Multi-window support

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -161,7 +161,7 @@ static inline void CreateDeviceExtensionArray(
 
 #define DEFAULT_PIPELINE_CACHE_FILE_NAME "FNA3D_Vulkan_PipelineCache.blob"
 
-#define WINDOW_SWAPCHAIN_DATA "swapchainData"
+#define WINDOW_SWAPCHAIN_DATA "FNA3D_VulkanSwapchain"
 
 #define IDENTITY_SWIZZLE \
 { \
@@ -6158,7 +6158,7 @@ static void VULKAN_INTERNAL_SubmitCommands(
 			mode.refresh_rate = 60;
 		}
 
-		swapchainData = (VulkanSwapchainData*)SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
+		swapchainData = (VulkanSwapchainData*) SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
 
 		if (swapchainData == NULL)
 		{
@@ -6168,7 +6168,7 @@ static void VULKAN_INTERNAL_SubmitCommands(
 				return;
 			}
 
-			swapchainData = (VulkanSwapchainData*)SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
+			swapchainData = (VulkanSwapchainData*) SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
 		}
 
 		/* Begin next frame */
@@ -6524,7 +6524,7 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 	VkSwapchainCreateInfoKHR swapchainCreateInfo;
 	VkImageViewCreateInfo createInfo;
 
-	swapchainData = (VulkanSwapchainData*)SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
+	swapchainData = (VulkanSwapchainData*) SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
 
 	if (swapchainData != NULL)
 	{
@@ -6686,7 +6686,7 @@ static void VULKAN_INTERNAL_DestroySwapchain(
 	uint32_t i;
 	VulkanSwapchainData *swapchainData;
 
-	swapchainData = (VulkanSwapchainData*)SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
+	swapchainData = (VulkanSwapchainData*) SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
 
 	if (swapchainData == NULL)
 	{

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6446,9 +6446,10 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	}
 
 	/* Now that commands are totally done, check if we need new swapchain */
-	if (present && validSwapchainExists)
+	if (present)
 	{
-		if (	acquireResult == VK_ERROR_OUT_OF_DATE_KHR ||
+		if (	!validSwapchainExists ||	
+			acquireResult == VK_ERROR_OUT_OF_DATE_KHR ||
 			acquireResult == VK_SUBOPTIMAL_KHR ||
 			presentResult == VK_ERROR_OUT_OF_DATE_KHR ||
 			presentResult == VK_SUBOPTIMAL_KHR	)

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -38,7 +38,7 @@
 #include <SDL.h>
 #include <SDL_vulkan.h>
 
-#define clamp(val, min, max) SDL_max(min, SDL_min(val, max))
+#define VULKAN_INTERNAL_clamp(val, min, max) SDL_max(min, SDL_min(val, max))
 
 /* Global Vulkan Loader Entry Points */
 
@@ -6170,7 +6170,7 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	{
 		SDL_GetCurrentDisplayMode(
 			SDL_GetWindowDisplayIndex(
-				windowHandle
+				(SDL_Window*) windowHandle
 			),
 			&mode
 		);
@@ -6417,7 +6417,7 @@ static void VULKAN_INTERNAL_SubmitCommands(
 	renderer->activeCommandBufferCount = 0;
 
 	/* Present, if applicable */
-	if (present && validSwapchainExists && acquireSuccess)
+	if (present && acquireSuccess)
 	{
 		if (renderer->supports.GGP_frame_token)
 		{
@@ -6628,7 +6628,6 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 			swapchainSupportDetails.formatsLength,
 			&swapchainData->surfaceFormat
 		)) {
-			FNA3D_LogError("Device does not support swap chain format");
 			if (swapchainSupportDetails.formatsLength > 0)
 			{
 				SDL_free(swapchainSupportDetails.formats);
@@ -6637,6 +6636,7 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 			{
 				SDL_free(swapchainSupportDetails.presentModes);
 			}
+			FNA3D_LogError("Device does not support swap chain format");
 			return CREATE_SWAPCHAIN_FAIL;
 		}
 	}
@@ -6647,7 +6647,6 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 		swapchainSupportDetails.presentModesLength,
 		&swapchainData->presentMode
 	)) {
-		FNA3D_LogError("Device does not support swap chain present mode");
 		if (swapchainSupportDetails.formatsLength > 0)
 		{
 			SDL_free(swapchainSupportDetails.formats);
@@ -6656,6 +6655,7 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 		{
 			SDL_free(swapchainSupportDetails.presentModes);
 		}
+		FNA3D_LogError("Device does not support swap chain present mode");
 		return CREATE_SWAPCHAIN_FAIL;
 	}
 
@@ -6689,12 +6689,12 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 		if (swapchainSupportDetails.capabilities.currentExtent.width != UINT32_MAX)
 		{
 			FNA3D_LogWarn("Falling back to an acceptable swapchain extent.");
-			drawableWidth = clamp(
+			drawableWidth = VULKAN_INTERNAL_clamp(
 				drawableWidth,
 				swapchainSupportDetails.capabilities.minImageExtent.width,
 				swapchainSupportDetails.capabilities.maxImageExtent.width
 			);
-			drawableHeight = clamp(
+			drawableHeight = VULKAN_INTERNAL_clamp(
 				drawableHeight,
 				swapchainSupportDetails.capabilities.minImageExtent.height,
 				swapchainSupportDetails.capabilities.maxImageExtent.height
@@ -12460,7 +12460,7 @@ static FNA3D_Device* VULKAN_CreateDevice(
 	 * Create initial swapchain
 	 */
 
-	renderer->swapchainDataCapacity = 4;
+	renderer->swapchainDataCapacity = 1;
 	renderer->swapchainDataCount = 0;
 	renderer->swapchainDatas = SDL_malloc(renderer->swapchainDataCapacity * sizeof(VulkanSwapchainData*));
 

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -10101,7 +10101,7 @@ static void VULKAN_ResetBackbuffer(
 	FNA3D_Renderer *driverData,
 	FNA3D_PresentationParameters *presentationParameters
 ) {
-	int32_t i, j;
+	int32_t i;
 
 	VulkanRenderer *renderer = (VulkanRenderer*) driverData;
 	renderer->presentInterval = presentationParameters->presentationInterval;
@@ -12248,7 +12248,7 @@ static FNA3D_Device* VULKAN_CreateDevice(
 		&renderer->swapchainSupportDetails
 	)) {
 		FNA3D_LogError("Device does not support swap chain creation");
-		return CREATE_SWAPCHAIN_FAIL;
+		return NULL;
 	}
 
 	renderer->swapchainFormat = renderer->backBufferIsSRGB
@@ -12279,7 +12279,7 @@ static FNA3D_Device* VULKAN_CreateDevice(
 			&renderer->surfaceFormat
 		)) {
 			FNA3D_LogError("Device does not support swap chain format");
-			return CREATE_SWAPCHAIN_FAIL;
+			return NULL;
 		}
 	}
 
@@ -12290,7 +12290,7 @@ static FNA3D_Device* VULKAN_CreateDevice(
 		&renderer->presentMode
 	)) {
 		FNA3D_LogError("Device does not support swap chain present mode");
-		return CREATE_SWAPCHAIN_FAIL;
+		return NULL;
 	}
 
 	renderer->vkDestroySurfaceKHR(renderer->instance, surface, NULL);

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -233,7 +233,7 @@ typedef enum CreateSwapchainResult
 {
 	CREATE_SWAPCHAIN_FAIL,
 	CREATE_SWAPCHAIN_SUCCESS,
-	CREATE_SWAPCHAIN_SURFACE_ZERO
+	CREATE_SWAPCHAIN_SURFACE_ZERO,
 } CreateSwapchainResult;
 
 /* Image Barriers */
@@ -1013,18 +1013,23 @@ static inline void PipelineLayoutHashArray_Insert(
 
 typedef struct VulkanSwapchainData
 {
-	VkSwapchainKHR swapchain;
+	/* Window surface */
 	VkSurfaceKHR surface;
 	VkSurfaceFormatKHR surfaceFormat;
-	VkPresentModeKHR presentMode;
+	void *windowHandle;
+
+	/* Swapchain for window surface */
+	VkSwapchainKHR swapchain;
 	VkFormat swapchainFormat;
 	VkComponentMapping swapchainSwizzle;
+	VkPresentModeKHR presentMode;
+
+	/* Swapchain images */
 	VkExtent2D extent;
 	VkImage *images;
-	VulkanResourceAccessType *resourceAccessTypes;
 	VkImageView *views;
+	VulkanResourceAccessType *resourceAccessTypes;
 	uint32_t imageCount;
-	void *windowHandle;
 } VulkanSwapchainData;
 
 typedef struct VulkanMemoryAllocation VulkanMemoryAllocation;
@@ -2080,7 +2085,7 @@ static uint8_t VULKAN_INTERNAL_QuerySwapChainSupport(
 
 	if (!supportsPresent)
 	{
-		FNA3D_LogError("This surface does not support presenting!");
+		FNA3D_LogWarn("This surface does not support presenting!");
 		return 0;
 	}
 

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6523,6 +6523,7 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 	VulkanSwapchainData *swapchainData;
 	VkSwapchainCreateInfoKHR swapchainCreateInfo;
 	VkImageViewCreateInfo createInfo;
+	VkBool32 supportsPresent;
 
 	swapchainData = (VulkanSwapchainData*) SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
 
@@ -6568,6 +6569,19 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 			"SDL_Vulkan_CreateSurface failed: %s",
 			SDL_GetError()
 		);
+		return CREATE_SWAPCHAIN_FAIL;
+	}
+
+	renderer->vkGetPhysicalDeviceSurfaceSupportKHR(
+		renderer->physicalDevice,
+		renderer->queueFamilyIndex,
+		swapchainData->surface,
+		&supportsPresent
+	);
+
+	if (!supportsPresent)
+	{
+		FNA3D_LogError("This surface does not support presenting!");
 		return CREATE_SWAPCHAIN_FAIL;
 	}
 


### PR DESCRIPTION
This patch uses a dictionary of window handles to swapchains to blit the faux-backbuffer to the appropriate swapchain to handle multiple windows on the same device.

Some outstanding concerns: Now that we aren't using a one swapchain assumption, the initialization flow feels slightly awkward. This is related to the special cases for `deviceWindowHandle` in the swapchain functions. We might want to consider initializing with a dummy surface similar to the `PrepareWindowAttributes` flow and then handling windows/surfaces/swapchains as always-bundled units, but I'm not sure if this would also be awkward.