### PR TITLE
Vulkan: Buffer synchronization rework

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4862,7 +4862,7 @@ static VulkanBuffer* VULKAN_INTERNAL_CreateBuffer(
 
 	buffer->size = size;
 	buffer->resourceAccessType = resourceAccessType;
-	buffer->usage = usage | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+	buffer->usage = usage | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 	buffer->preferDeviceLocal = isDeviceLocal;
 	buffer->isStagingBuffer = isStagingBuffer;
 

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4959,6 +4959,7 @@ static void VULKAN_INTERNAL_CreateFastStagingBuffers(
 		1,
 		1
 	);
+	renderer->stagingBuffers[0].fastBufferOffset = 0;
 
 	renderer->stagingBuffers[1].fastBuffer = (VulkanBuffer*) VULKAN_INTERNAL_CreateBuffer(
 		renderer,
@@ -4968,13 +4969,15 @@ static void VULKAN_INTERNAL_CreateFastStagingBuffers(
 		1,
 		1
 	);
+	renderer->stagingBuffers[0].fastBufferOffset = 0;
 }
 
-static void VULKAN_INTERNAL_CreateSlowStagingBuffers(
+static void VULKAN_INTERNAL_CreateSlowStagingBuffer(
 	VulkanRenderer *renderer,
-	VkDeviceSize size
+	VkDeviceSize size,
+	uint32_t index
 ) {
-	renderer->stagingBuffers[0].slowBuffer = (VulkanBuffer*) VULKAN_INTERNAL_CreateBuffer(
+	renderer->stagingBuffers[index].slowBuffer = (VulkanBuffer*) VULKAN_INTERNAL_CreateBuffer(
 		renderer,
 		size,
 		RESOURCE_ACCESS_MEMORY_TRANSFER_READ_WRITE,
@@ -4983,24 +4986,12 @@ static void VULKAN_INTERNAL_CreateSlowStagingBuffers(
 		1
 	);
 
-	if (renderer->stagingBuffers[0].slowBuffer == NULL)
+	if (renderer->stagingBuffers[index].slowBuffer == NULL)
 	{
 		FNA3D_LogError("Failed to create slow texture staging buffer!");
 	}
 
-	renderer->stagingBuffers[1].slowBuffer = (VulkanBuffer*) VULKAN_INTERNAL_CreateBuffer(
-		renderer,
-		size,
-		RESOURCE_ACCESS_MEMORY_TRANSFER_READ_WRITE,
-		VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-		0,
-		1
-	);
-
-	if (renderer->stagingBuffers[1].slowBuffer == NULL)
-	{
-		FNA3D_LogError("Failed to create slow texture staging buffer!");
-	}
+	renderer->stagingBuffers[index].slowBufferOffset = 0;
 }
 
 static void VULKAN_INTERNAL_ExpandSlowStagingBuffer(
@@ -5023,9 +5014,10 @@ static void VULKAN_INTERNAL_ExpandSlowStagingBuffer(
 			renderer->stagingBuffers[renderer->stagingIndex].slowBuffer
 		);
 
-		VULKAN_INTERNAL_CreateSlowStagingBuffers(
+		VULKAN_INTERNAL_CreateSlowStagingBuffer(
 			renderer,
-			nextStagingSize
+			nextStagingSize,
+			renderer->stagingIndex
 		);
 	}
 }
@@ -5165,12 +5157,8 @@ static void VULKAN_INTERNAL_CreateStagingBuffer(
 	VulkanRenderer *renderer
 ) {
 	VULKAN_INTERNAL_CreateFastStagingBuffers(renderer, FAST_STAGING_SIZE);
-	renderer->stagingBuffers[0].fastBufferOffset = 0;
-	renderer->stagingBuffers[1].fastBufferOffset = 0;
-
-	VULKAN_INTERNAL_CreateSlowStagingBuffers(renderer, STARTING_SLOW_STAGING_SIZE);
-	renderer->stagingBuffers[0].slowBufferOffset = 0;
-	renderer->stagingBuffers[1].slowBufferOffset = 0;
+	VULKAN_INTERNAL_CreateSlowStagingBuffer(renderer, STARTING_SLOW_STAGING_SIZE, 0);
+	VULKAN_INTERNAL_CreateSlowStagingBuffer(renderer, STARTING_SLOW_STAGING_SIZE, 1);
 }
 
 /* Vulkan: Descriptor Set Logic */

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6948,9 +6948,9 @@ static void VULKAN_INTERNAL_SetBufferData(
 	VkBufferCopy bufferCopy;
 	uint32_t i;
 
-	if (options == FNA3D_SETDATAOPTIONS_NONE && vulkanBuffer->bound)
+	if (options == FNA3D_SETDATAOPTIONS_NONE)
 	{
-		/* If NONE is set and the buffer was bound, we need to do a buffered copy.
+		/* If NONE is set, we need to do a buffered copy.
 		 * The barriers will synchronize on the GPU so the data isn't overwritten
 		 * before it needs to be used.
 		 */

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6948,9 +6948,9 @@ static void VULKAN_INTERNAL_SetBufferData(
 	VkBufferCopy bufferCopy;
 	uint32_t i;
 
-	if (options == FNA3D_SETDATAOPTIONS_NONE)
+	if (options == FNA3D_SETDATAOPTIONS_NONE && vulkanBuffer->bound)
 	{
-		/* If NONE is set, we need to do a buffered copy.
+		/* If NONE is set and the buffer was bound, we need to do a buffered copy.
 		 * The barriers will synchronize on the GPU so the data isn't overwritten
 		 * before it needs to be used.
 		 */

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6898,14 +6898,14 @@ static void VULKAN_INTERNAL_SetBufferData(
 	VkDeviceSize stagingOffset;
 	VkBufferCopy bufferCopy;
 
-	VULKAN_INTERNAL_MaybeEndRenderPass(renderer, 1);
-
 	if (options == FNA3D_SETDATAOPTIONS_NONE || options == FNA3D_SETDATAOPTIONS_DISCARD)
 	{
 		/* If NONE or DISCARD is set, we need to do a buffered copy.
 		 * The barrier will synchronize on the GPU so the data isn't overwritten
 		 * before it needs to be used.
 		 */
+
+		VULKAN_INTERNAL_MaybeEndRenderPass(renderer, 1);
 
 		SDL_LockMutex(renderer->passLock);
 		SDL_LockMutex(renderer->stagingLock);

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4969,7 +4969,7 @@ static void VULKAN_INTERNAL_CreateFastStagingBuffers(
 		1,
 		1
 	);
-	renderer->stagingBuffers[0].fastBufferOffset = 0;
+	renderer->stagingBuffers[1].fastBufferOffset = 0;
 }
 
 static void VULKAN_INTERNAL_CreateSlowStagingBuffer(
@@ -6914,7 +6914,10 @@ static void VULKAN_INTERNAL_MarkBufferAsBound(
 	VulkanRenderer *renderer,
 	VulkanBuffer *vulkanBuffer
 ) {
-	if (vulkanBuffer->bound) { return; }
+	if (vulkanBuffer->bound)
+	{
+		return;
+	}
 
 	vulkanBuffer->bound = 1;
 
@@ -11271,6 +11274,7 @@ static void VULKAN_SetIndexBufferData(
 	int32_t dataLength,
 	FNA3D_SetDataOptions options
 ) {
+	/* FIXME: use staging buffer for elementSizeInBytes < vertexStride */
 	VULKAN_INTERNAL_SetBufferData(
 		driverData,
 		buffer,

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -151,9 +151,9 @@ static inline void CreateDeviceExtensionArray(
 #define STARTING_ALLOCATION_SIZE 64000000 /* 64MB */
 #define ALLOCATION_INCREMENT 16000000 /* 16MB */
 #define MAX_ALLOCATION_SIZE 256000000 /* 256MB */
-#define FAST_TEXTURE_STAGING_SIZE 64000000 /* 64MB */
-#define STARTING_SLOW_TEXTURE_STAGING_SIZE 16000000 /* 16MB */
-#define MAX_SLOW_TEXTURE_STAGING_SIZE 256000000 /* 256MB */
+#define FAST_STAGING_SIZE 64000000 /* 64MB */
+#define STARTING_SLOW_STAGING_SIZE 16000000 /* 16MB */
+#define MAX_SLOW_STAGING_SIZE 128000000 /* 128MB */
 
 /* Should be equivalent to the number of values in FNA3D_PrimitiveType */
 #define PRIMITIVE_TYPES_COUNT 5
@@ -4990,7 +4990,7 @@ static void VULKAN_INTERNAL_ExpandSlowStagingBuffer(
 ) {
 	VkDeviceSize nextStagingSize = renderer->stagingBuffers[renderer->stagingIndex].slowBuffer->size;
 
-	if (renderer->stagingBuffers[renderer->stagingIndex].slowBuffer->size < MAX_SLOW_TEXTURE_STAGING_SIZE)
+	if (renderer->stagingBuffers[renderer->stagingIndex].slowBuffer->size < MAX_SLOW_STAGING_SIZE)
 	{
 		nextStagingSize *= 2;
 
@@ -5145,11 +5145,11 @@ static void VULKAN_INTERNAL_PrepareCopyFromStagingBuffer(
 static void VULKAN_INTERNAL_CreateStagingBuffer(
 	VulkanRenderer *renderer
 ) {
-	VULKAN_INTERNAL_CreateFastStagingBuffers(renderer, FAST_TEXTURE_STAGING_SIZE);
+	VULKAN_INTERNAL_CreateFastStagingBuffers(renderer, FAST_STAGING_SIZE);
 	renderer->stagingBuffers[0].fastBufferOffset = 0;
 	renderer->stagingBuffers[1].fastBufferOffset = 0;
 
-	VULKAN_INTERNAL_CreateSlowStagingBuffers(renderer, STARTING_SLOW_TEXTURE_STAGING_SIZE);
+	VULKAN_INTERNAL_CreateSlowStagingBuffers(renderer, STARTING_SLOW_STAGING_SIZE);
 	renderer->stagingBuffers[0].slowBufferOffset = 0;
 	renderer->stagingBuffers[1].slowBufferOffset = 0;
 }

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6898,6 +6898,8 @@ static void VULKAN_INTERNAL_SetBufferData(
 	VkDeviceSize stagingOffset;
 	VkBufferCopy bufferCopy;
 
+	VULKAN_INTERNAL_MaybeEndRenderPass(renderer, 1);
+
 	if (options == FNA3D_SETDATAOPTIONS_NONE || options == FNA3D_SETDATAOPTIONS_DISCARD)
 	{
 		/* If NONE or DISCARD is set, we need to do a buffered copy.

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -3489,7 +3489,7 @@ static uint8_t VULKAN_INTERNAL_BindResourceMemory(
 	if (	(buffer == VK_NULL_HANDLE && image == VK_NULL_HANDLE) ||
 		(buffer != VK_NULL_HANDLE && image != VK_NULL_HANDLE)	)
 	{
-		FNA3D_LogError("BindResourceMemory must be given either a VulkanSubBuffer or a VulkanTexture");
+		FNA3D_LogError("BindResourceMemory must be given either a VulkanBuffer or a VulkanTexture");
 		return 0;
 	}
 

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -11166,6 +11166,7 @@ static void VULKAN_SetVertexBufferData(
 	int32_t vertexStride,
 	FNA3D_SetDataOptions options
 ) {
+	/* FIXME: use staging buffer for elementSizeInBytes < vertexStride */
 	VULKAN_INTERNAL_SetBufferData(
 		driverData,
 		buffer,
@@ -11274,7 +11275,6 @@ static void VULKAN_SetIndexBufferData(
 	int32_t dataLength,
 	FNA3D_SetDataOptions options
 ) {
-	/* FIXME: use staging buffer for elementSizeInBytes < vertexStride */
 	VULKAN_INTERNAL_SetBufferData(
 		driverData,
 		buffer,


### PR DESCRIPTION
Currently, the Vulkan renderer does direct copies for buffer data uploads. We have a lot of complex logic to make sure data is synchronized correctly and that buffer data doesn't get clobbered while it's in-flight. 

This patch changes our buffer upload logic to streamline the buffer upload process. 

If NONE or DISCARD is set, we first copy the data to a staging buffer. Then we record a `vkCmdCopyBuffer` command, which is GPU-synchronized. This prevents data from being overwritten in the middle of a graphics operation. 

If NOOVERWRITE is set then we just directly copy over data like we were doing before. 

The benefits of this approach are most obvious in the `VULKAN_INTERNAL_SetBufferData` function, which is much cleaner and simpler to understand now. I was able to remove a lot of record keeping related to buffers, since they no longer need to keep track of bound sub-buffers to avoid unwanted data overwrites.

I also split the staging buffer into two separate buffers to avoid needing to stall when data is uploaded over multiple frames.

We'll probably want to test this on a bunch of traces but my preliminary tests show no problems with this patch. The only downside is an extra 64MB of allocation for the fast staging buffer.