### PR TITLE
D3D11: Fall back to feature level 11_0 if 11_1 is unsupported

### DIFF
--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -4740,6 +4740,23 @@ static uint8_t D3D11_PrepareWindowAttributes(uint32_t *flags)
 		NULL
 	);
 
+	if (FAILED(res))
+	{
+		FNA3D_LogWarn("Creating device with feature level 11_1 failed. Lowering feature level.", res);
+		res = D3D11CreateDeviceFunc(
+			NULL,
+			D3D_DRIVER_TYPE_HARDWARE,
+			NULL,
+			D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+			&levels[1],
+			SDL_arraysize(levels) - 1,
+			D3D11_SDK_VERSION,
+			NULL,
+			NULL,
+			NULL
+		);
+	}
+
 	D3D11_PLATFORM_UnloadD3D11(module);
 
 	if (FAILED(res))
@@ -4968,6 +4985,7 @@ static FNA3D_Device* D3D11_CreateDevice(
 		D3D_FEATURE_LEVEL_10_1,
 		D3D_FEATURE_LEVEL_10_0
 	};
+	uint32_t featureLevelIndex = 0;
 	uint32_t flags, supportsDxt3, supportsDxt5, supportsSrgb;
 	int32_t i;
 	HRESULT res;
@@ -5018,22 +5036,35 @@ try_create_device:
 		D3D_DRIVER_TYPE_HARDWARE,
 		NULL,
 		flags,
-		levels,
-		SDL_arraysize(levels),
+		&levels[featureLevelIndex],
+		SDL_arraysize(levels) - featureLevelIndex,
 		D3D11_SDK_VERSION,
 		&renderer->device,
 		&renderer->featureLevel,
 		&renderer->context
 	);
 
-	if (FAILED(res) && debugMode)
+	if (FAILED(res))
 	{
-		/* Creating a debug mode device will fail on some systems due to the necessary
-		 * debug infrastructure not being available. Remove the debug flag and retry. */
-		FNA3D_LogWarn("Creating device in debug mode failed with error %08X. Trying non-debug.", res);
-		flags ^= D3D11_CREATE_DEVICE_DEBUG;
-		debugMode = 0;
-		goto try_create_device;
+		if (debugMode)
+		{
+			/* Creating a debug mode device will fail on some systems due to the necessary
+			* debug infrastructure not being available. Remove the debug flag and retry. */
+			FNA3D_LogWarn("Creating device in debug mode failed with error %08X. Trying non-debug.", res);
+			flags ^= D3D11_CREATE_DEVICE_DEBUG;
+			goto try_create_device;
+		}
+		else if (featureLevelIndex == 0)
+		{
+			FNA3D_LogWarn("Creating device with feature level 11_1 failed. Lowering feature level.", res);
+			featureLevelIndex = 1;
+			if (debugMode)
+			{
+				/* Since we're lowering the feature level, let's try setting debug mode again. */
+				flags |= D3D11_CREATE_DEVICE_DEBUG;
+			}
+			goto try_create_device;
+		}
 	}
 
 	ERROR_CHECK_RETURN("Could not create D3D11Device", NULL)
@@ -5105,7 +5136,7 @@ try_create_device:
 	}
 
 	/* Initialize renderer members not covered by SDL_memset('\0') */
-	renderer->debugMode = debugMode;
+	renderer->debugMode = flags & D3D11_CREATE_DEVICE_DEBUG;
 	renderer->blendFactor.r = 0xFF;
 	renderer->blendFactor.g = 0xFF;
 	renderer->blendFactor.b = 0xFF;
@@ -5359,7 +5390,7 @@ static void D3D11_PLATFORM_GetDefaultAdapter(
 		&D3D_IID_IDXGIFactory6,
 		(void**) &factory6
 	);
-	if (SUCCEEDED(res)) 
+	if (SUCCEEDED(res))
 	{
 		IDXGIFactory6_EnumAdapterByGpuPreference(
 			(IDXGIFactory6*) factory6,
@@ -5369,7 +5400,7 @@ static void D3D11_PLATFORM_GetDefaultAdapter(
 			(void**) adapter
 		);
 	}
-	else 
+	else
 	{
 		IDXGIFactory1_EnumAdapters1(
 			(IDXGIFactory1*) factory,
@@ -5392,7 +5423,7 @@ static void ResolveSwapChainModeDescription(
 	IDXGIAdapter1* pAdapter;
 	IDXGIOutput *output;
 	DXGI_OUTPUT_DESC description;
-	
+
 	/* Find the output (on any adapter) attached to the monitor that holds our window */
 	monitor = MonitorFromWindow(window, MONITOR_DEFAULTTOPRIMARY);
 	while (SUCCEEDED(IDXGIFactory1_EnumAdapters1(factory, iAdapter++, &pAdapter)))

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -5049,7 +5049,8 @@ try_create_device:
 		if (flags & D3D11_CREATE_DEVICE_DEBUG)
 		{
 			/* Creating a debug mode device will fail on some systems due to the necessary
-			* debug infrastructure not being available. Remove the debug flag and retry. */
+			* debug infrastructure not being available. Remove the debug flag and retry.
+			*/
 			FNA3D_LogWarn("Creating device in debug mode failed with error %08X. Trying non-debug.", res);
 			flags &= ~(D3D11_CREATE_DEVICE_DEBUG);
 			goto try_create_device;

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -5032,8 +5032,8 @@ static FNA3D_Device* D3D11_CreateDevice(
 
 try_create_device:
 	res = D3D11CreateDeviceFunc(
-		NULL, /* FIXME: Should be renderer->adapter! */
-		D3D_DRIVER_TYPE_HARDWARE,
+		renderer->adapter,
+		D3D_DRIVER_TYPE_UNKNOWN, /* must be UNKNOWN if adapter is non-null according to spec */
 		NULL,
 		flags,
 		&levels[featureLevelIndex],
@@ -5046,12 +5046,12 @@ try_create_device:
 
 	if (FAILED(res))
 	{
-		if (debugMode)
+		if (flags & D3D11_CREATE_DEVICE_DEBUG)
 		{
 			/* Creating a debug mode device will fail on some systems due to the necessary
 			* debug infrastructure not being available. Remove the debug flag and retry. */
 			FNA3D_LogWarn("Creating device in debug mode failed with error %08X. Trying non-debug.", res);
-			flags ^= D3D11_CREATE_DEVICE_DEBUG;
+			flags &= ~(D3D11_CREATE_DEVICE_DEBUG);
 			goto try_create_device;
 		}
 		else if (featureLevelIndex == 0)

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -4985,6 +4985,7 @@ static FNA3D_Device* D3D11_CreateDevice(
 		D3D_FEATURE_LEVEL_10_1,
 		D3D_FEATURE_LEVEL_10_0
 	};
+	uint32_t featureLevelIndex = 0;
 	uint32_t flags, supportsDxt3, supportsDxt5, supportsSrgb;
 	int32_t i;
 	HRESULT res;
@@ -5023,113 +5024,46 @@ static FNA3D_Device* D3D11_CreateDevice(
 	}
 
 	/* Create the D3D11Device */
-
 	flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 	if (debugMode)
 	{
 		flags |= D3D11_CREATE_DEVICE_DEBUG;
 	}
 
+try_create_device:
 	res = D3D11CreateDeviceFunc(
-		(IDXGIAdapter*) renderer->adapter,
+		renderer->adapter,
 		D3D_DRIVER_TYPE_UNKNOWN, /* must be UNKNOWN if adapter is non-null according to spec */
 		NULL,
 		flags,
-		levels,
-		SDL_arraysize(levels),
+		&levels[featureLevelIndex],
+		SDL_arraysize(levels) - featureLevelIndex,
 		D3D11_SDK_VERSION,
 		&renderer->device,
 		&renderer->featureLevel,
 		&renderer->context
 	);
 
-	if (debugMode)
+	if (FAILED(res))
 	{
-		if (FAILED(res))
+		if (flags & D3D11_CREATE_DEVICE_DEBUG)
 		{
 			/* Creating a debug mode device will fail on some systems due to the necessary
-			* debug infrastructure not being available. Remove the debug flag and retry.
-			*/
-
-			FNA3D_LogWarn("Creating device with feature level 11.1 in debug mode failed with error %08X. Trying non-debug.", res);
+			* debug infrastructure not being available. Remove the debug flag and retry. */
+			FNA3D_LogWarn("Creating device in debug mode failed with error %08X. Trying non-debug.", res);
 			flags &= ~(D3D11_CREATE_DEVICE_DEBUG);
-
-			res = D3D11CreateDeviceFunc(
-				(IDXGIAdapter*) renderer->adapter,
-				D3D_DRIVER_TYPE_UNKNOWN, /* must be UNKNOWN if adapter is non-null according to spec */
-				NULL,
-				flags,
-				levels,
-				SDL_arraysize(levels),
-				D3D11_SDK_VERSION,
-				&renderer->device,
-				&renderer->featureLevel,
-				&renderer->context
-			);
-
-			if (FAILED(res))
-			{
-				/* We failed again, so let's try lowering the feature level to 11.0 and setting the debug flag again. */
-
-				FNA3D_LogWarn("Creating device with feature level 11.1 failed. Lowering to 11.0 with debug.");
-				flags |= D3D11_CREATE_DEVICE_DEBUG;
-
-				res = D3D11CreateDeviceFunc(
-					(IDXGIAdapter*) renderer->adapter,
-					D3D_DRIVER_TYPE_UNKNOWN, /* must be UNKNOWN if adapter is non-null according to spec */
-					NULL,
-					flags,
-					&levels[1],
-					SDL_arraysize(levels) - 1,
-					D3D11_SDK_VERSION,
-					&renderer->device,
-					&renderer->featureLevel,
-					&renderer->context
-				);
-
-				if (FAILED(res))
-				{
-					/* We failed again, so let's try unsetting the debug flag again. */
-
-					FNA3D_LogWarn("Creating device with feature level 11.0 and debug mode failed. Trying non-debug.");
-					flags &= ~(D3D11_CREATE_DEVICE_DEBUG);
-
-					res = D3D11CreateDeviceFunc(
-						(IDXGIAdapter*) renderer->adapter,
-						D3D_DRIVER_TYPE_UNKNOWN, /* must be UNKNOWN if adapter is non-null according to spec */
-						NULL,
-						flags,
-						&levels[1],
-						SDL_arraysize(levels) - 1,
-						D3D11_SDK_VERSION,
-						&renderer->device,
-						&renderer->featureLevel,
-						&renderer->context
-					);
-				}
-			}
+			goto try_create_device;
 		}
-	}
-	else
-	{
-		if (FAILED(res))
+		else if (featureLevelIndex == 0)
 		{
-			/* Let's try lowering the feature level to 11.0. */
-
-			FNA3D_LogWarn("Creating device with feature level 11.1 failed. Lowering to 11.0.");
-
-			res = D3D11CreateDeviceFunc(
-				(IDXGIAdapter*) renderer->adapter,
-				D3D_DRIVER_TYPE_UNKNOWN, /* must be UNKNOWN if adapter is non-null according to spec */
-				NULL,
-				flags,
-				&levels[1],
-				SDL_arraysize(levels) - 1,
-				D3D11_SDK_VERSION,
-				&renderer->device,
-				&renderer->featureLevel,
-				&renderer->context
-			);
+			FNA3D_LogWarn("Creating device with feature level 11_1 failed. Lowering feature level.", res);
+			featureLevelIndex = 1;
+			if (debugMode)
+			{
+				/* Since we're lowering the feature level, let's try setting debug mode again. */
+				flags |= D3D11_CREATE_DEVICE_DEBUG;
+			}
+			goto try_create_device;
 		}
 	}
 


### PR DESCRIPTION
Apparently feature level 11_1 is special and will throw an error if unsupported, unlike every other feature level. Fun!

Marking as a draft until the person who reported this is able to test.