### PR TITLE
Vulkan: Fix SetBufferData race on defrag frames

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -1895,8 +1895,8 @@ static void VULKAN_INTERNAL_ImageMemoryBarrier(
 );
 
 static void VULKAN_INTERNAL_MarkBufferAsBound(
-	VulkanRenderer* renderer,
-	VulkanBuffer* vulkanBuffer
+	VulkanRenderer *renderer,
+	VulkanBuffer *vulkanBuffer
 );
 
 static void VULKAN_INTERNAL_MarkBufferForDestroy(

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -1894,6 +1894,11 @@ static void VULKAN_INTERNAL_ImageMemoryBarrier(
 	VulkanResourceAccessType *resourceAccessType
 );
 
+static void VULKAN_INTERNAL_MarkBufferAsBound(
+	VulkanRenderer* renderer,
+	VulkanBuffer* vulkanBuffer
+);
+
 static void VULKAN_INTERNAL_MarkBufferForDestroy(
 	VulkanRenderer *renderer,
 	VulkanBuffer *vulkanBuffer

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -1355,6 +1355,7 @@ typedef struct VulkanRenderer
 	VkSemaphore renderFinishedSemaphore;
 	VkSemaphore defragSemaphore;
 
+	uint8_t bufferDefragInProgress;
 	uint8_t needDefrag;
 	uint32_t defragTimer;
 	uint8_t resourceFreed;
@@ -4095,7 +4096,11 @@ static uint8_t VULKAN_INTERNAL_DefragmentMemory(
 				newRegion->vulkanBuffer->buffer = copyBuffer;
 				newRegion->vulkanBuffer->resourceAccessType = copyResourceAccessType;
 
+				/* Binding prevents data race when using SetBufferData with Discard option */
+				VULKAN_INTERNAL_MarkBufferAsBound(renderer, newRegion->vulkanBuffer);
+
 				renderer->needDefrag = 1;
+				renderer->bufferDefragInProgress = 1;
 			}
 			else
 			{
@@ -6179,6 +6184,8 @@ static void VULKAN_INTERNAL_SubmitCommands(
 
 	renderer->submittedCommandBufferCount = 0;
 
+	renderer->bufferDefragInProgress = 0;
+
 	/* Decide if we will be defragmenting */
 	if (renderer->resourceFreed)
 	{
@@ -6356,6 +6363,8 @@ static void VULKAN_INTERNAL_FlushCommands(VulkanRenderer *renderer, uint8_t sync
 		{
 			FNA3D_LogWarn("vkWaitForFences: %s", VkErrorMessages(result));
 		}
+
+		renderer->bufferDefragInProgress = 0;
 	}
 
 	SDL_UnlockMutex(renderer->passLock);
@@ -7046,6 +7055,20 @@ static void VULKAN_INTERNAL_SetBufferData(
 			}
 
 			vulkanBuffer = vulkanBufferContainer->vulkanBuffer;
+		}
+
+		/* If this is a defrag frame and NoOverwrite is set, wait for defrag to avoid data race */
+		if (options == FNA3D_SETDATAOPTIONS_NOOVERWRITE && renderer->bufferDefragInProgress)
+		{
+			renderer->vkWaitForFences(
+				renderer->logicalDevice,
+				1,
+				&renderer->defragFence,
+				VK_TRUE,
+				UINT64_MAX
+			);
+
+			renderer->bufferDefragInProgress = 0;
 		}
 
 		SDL_memcpy(
@@ -12987,6 +13010,7 @@ static FNA3D_Device* VULKAN_CreateDevice(
 		renderer->boundBufferCapacity * sizeof(VulkanBuffer*)
 	);
 
+	renderer->bufferDefragInProgress = 0;
 	renderer->needDefrag = 0;
 	renderer->defragTimer = 0;
 	renderer->resourceFreed = 0;


### PR DESCRIPTION
The defragmentation process performs async copies on the GPU, which we don't control the timing of, so under certain conditions the GPU can perform the copy after SetBufferData is called which will destroy user data. For None, async copies are performed using memory barriers so no race is possible. For Discard, marking the moved buffer as bound is enough to prevent a race because an unbound buffer will be selected or created. For NoOverwrite we have no choice but to wait on the defrag fence.