### PR TITLE
Vulkan: Remove unnecessary swapchain data check

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6421,15 +6421,6 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 	uint8_t swapchainSupport;
 	int32_t drawableWidth, drawableHeight;
 
-	swapchainData = (VulkanSwapchainData*) SDL_GetWindowData(windowHandle, WINDOW_SWAPCHAIN_DATA);
-
-	if (swapchainData != NULL)
-	{
-		SDL_free(swapchainData);
-		FNA3D_LogError("Swapchain already exists for this window! Destroy it first!");
-		return CREATE_SWAPCHAIN_FAIL;
-	}
-
 	swapchainData = SDL_malloc(sizeof(VulkanSwapchainData));
 	swapchainData->windowHandle = windowHandle;
 


### PR DESCRIPTION
Noticed an erroneous free, but it turns out that this block of code will never be executed anyway so I just removed it.