### PR TITLE
Add missing render pass mutex unlock

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -8808,6 +8808,8 @@ static void VULKAN_INTERNAL_BeginRenderPass(
 	renderer->shouldClearColorOnBeginPass = 0;
 	renderer->shouldClearDepthOnBeginPass = 0;
 	renderer->shouldClearStencilOnBeginPass = 0;
+
+	SDL_UnlockMutex(renderer->passLock);
 }
 
 static void VULKAN_INTERNAL_BeginRenderPassClear(


### PR DESCRIPTION
I think it should be unlocked afterwards, I was experiencing some freeze with this mutex and found out that at this call it was not unlocked. Add an unlock fixed the freeze.