### PR TITLE
Vulkan: Use identity transform for Vulkan swapchain

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -6630,7 +6630,7 @@ static CreateSwapchainResult VULKAN_INTERNAL_CreateSwapchain(
 	swapchainCreateInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
 	swapchainCreateInfo.queueFamilyIndexCount = 0;
 	swapchainCreateInfo.pQueueFamilyIndices = NULL;
-	swapchainCreateInfo.preTransform = swapchainSupportDetails.capabilities.currentTransform;
+	swapchainCreateInfo.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
 	swapchainCreateInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 	swapchainCreateInfo.presentMode = swapchainData->presentMode;
 	swapchainCreateInfo.clipped = VK_TRUE;


### PR DESCRIPTION
XNA game works with rotated framebuffer, so Android has to rotate them again for native display (for [reference](https://community.arm.com/arm-community-blogs/b/graphics-gaming-and-vr-blog/posts/appropriate-use-of-surface-rotation)). So I use identity transform to fix the graphics.

Without the change I got some ported games squeezed in potrait resolution while it's meant to be in landscape.