### PR TITLE
Vulkan: Same-access-type barrier should not be a no-op

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -4680,11 +4680,6 @@ static void VULKAN_INTERNAL_BufferMemoryBarrier(
 	VulkanResourceAccessType prevAccess, nextAccess;
 	const VulkanResourceAccessInfo *prevAccessInfo, *nextAccessInfo;
 
-	if (*resourceAccessType == nextResourceAccessType)
-	{
-		return;
-	}
-
 	SDL_LockMutex(renderer->passLock);
 
 	memoryBarrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
@@ -4764,11 +4759,6 @@ static void VULKAN_INTERNAL_ImageMemoryBarrier(
 	VkImageMemoryBarrier memoryBarrier;
 	VulkanResourceAccessType prevAccess;
 	const VulkanResourceAccessInfo *pPrevAccessInfo, *pNextAccessInfo;
-
-	if (*resourceAccessType == nextAccess)
-	{
-		return;
-	}
 
 	SDL_LockMutex(renderer->passLock);
 
@@ -4905,13 +4895,6 @@ static VulkanBuffer* VULKAN_INTERNAL_CreateBuffer(
 	}
 
 	buffer->usedRegion->vulkanBuffer = buffer; /* lol */
-
-	VULKAN_INTERNAL_BufferMemoryBarrier(
-		renderer,
-		buffer->resourceAccessType,
-		buffer->buffer,
-		&buffer->resourceAccessType
-	);
 
 	return buffer;
 }


### PR DESCRIPTION
We'll probably want to run a few traces on this just to be safe, but [this test](https://gist.github.com/TheSpydog/78ca18ee3bc0416e576f6710a80c0aa3) should now be consistent between Vulkan and the other backends. 