### PR TITLE
Update MojoShader to point to valid branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "MojoShader"]
 	path = MojoShader
 	url = https://github.com/icculus/mojoshader
-	branch = upstream
+	branch = main
 [submodule "Vulkan-Headers"]
 	path = Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers


### PR DESCRIPTION
Apparently the MojoShader repo deleted the upstream branch. I think the main branch is the intended upstream submodule branch? If not it's either that or the fna branch.