### PR TITLE
Vulkan: Restructure memory barriers to avoid breaking render pass

### DIFF
--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -8739,11 +8739,7 @@ static void VULKAN_INTERNAL_BeginRenderPass(
 	{
 		renderer->colorAttachments[i] = renderer->nextRenderPassColorAttachments[i];
 		renderer->attachmentCubeFaces[i] = renderer->nextRenderPassAttachmentCubeFaces[i];
-
-		if (renderer->nextRenderPassMultiSampleCount > 1)
-		{
-			renderer->colorMultiSampleAttachments[i] = renderer->nextRenderPassColorMultiSampleAttachments[i];
-		}
+		renderer->colorMultiSampleAttachments[i] = renderer->nextRenderPassColorMultiSampleAttachments[i]; /* may be NULL */
 	}
 
 	renderer->colorAttachmentCount = renderer->nextRenderPassColorAttachmentCount;

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -8259,22 +8259,25 @@ static uint8_t VULKAN_INTERNAL_CreateFauxBackbuffer(
 
 		if (!renderer->renderTargetBound)
 		{
-			renderer->depthStencilAttachment =
+			renderer->nextRenderPassDepthStencilAttachment =
 				renderer->fauxBackbufferDepthStencil.handle;
+
+			renderer->nextRenderPassDepthFormat =
+				presentationParameters->depthStencilFormat;
 		}
 	}
 
 	if (!renderer->renderTargetBound)
 	{
-		renderer->colorAttachments[0] =
+		renderer->nextRenderPassColorAttachments[0] =
 			renderer->fauxBackbufferColor.handle;
-		renderer->colorAttachmentCount = 1;
+		renderer->nextRenderPassColorAttachmentCount = 1;
 
 		if (renderer->fauxBackbufferMultiSampleCount > 0)
 		{
-			renderer->colorMultiSampleAttachments[0] =
+			renderer->nextRenderPassColorMultiSampleAttachments[0] =
 				renderer->fauxBackbufferMultiSampleColor;
-			renderer->multiSampleCount =
+			renderer->nextRenderPassMultiSampleCount =
 				renderer->fauxBackbufferMultiSampleCount;
 		}
 	}


### PR DESCRIPTION
Addresses https://github.com/FNA-XNA/FNA3D/issues/165

We should really only have been setting memory barriers in cases where a data race was actually possible, so this patch addresses that. Memory barriers are only created on data copies, and when a render pass ends.

To help facilitate this change, SetRenderTargets now configures the state for the next render pass. That state is then set when the new render pass is triggered, instead of immediately.

The validation layer might complain now if you bind a resource that hasn't had any data written to it, but that seems acceptable to me.