### PR TITLE
Make Environment Variable values case-insensitive

### DIFF
--- a/src/FNA3D.c
+++ b/src/FNA3D.c
@@ -148,7 +148,7 @@ uint32_t FNA3D_PrepareWindowAttributes(void)
 	{
 		if (hint != NULL)
 		{
-			if (SDL_strcmp(hint, drivers[i]->Name) != 0)
+			if (SDL_strcasecmp(hint, drivers[i]->Name) != 0)
 			{
 				continue;
 			}

--- a/src/FNA3D_Driver_OpenGL.c
+++ b/src/FNA3D_Driver_OpenGL.c
@@ -5723,22 +5723,22 @@ static uint8_t OPENGL_PrepareWindowAttributes(uint32_t *flags)
 	depthFormatHint = SDL_GetHint("FNA3D_OPENGL_WINDOW_DEPTHSTENCILFORMAT");
 	if (depthFormatHint != NULL)
 	{
-		if (SDL_strcmp(depthFormatHint, "None") == 0)
+		if (SDL_strcasecmp(depthFormatHint, "None") == 0)
 		{
 			depthSize = 0;
 			stencilSize = 0;
 		}
-		else if (SDL_strcmp(depthFormatHint, "Depth16") == 0)
+		else if (SDL_strcasecmp(depthFormatHint, "Depth16") == 0)
 		{
 			depthSize = 16;
 			stencilSize = 0;
 		}
-		else if (SDL_strcmp(depthFormatHint, "Depth24") == 0)
+		else if (SDL_strcasecmp(depthFormatHint, "Depth24") == 0)
 		{
 			depthSize = 24;
 			stencilSize = 0;
 		}
-		else if (SDL_strcmp(depthFormatHint, "Depth24Stencil8") == 0)
+		else if (SDL_strcasecmp(depthFormatHint, "Depth24Stencil8") == 0)
 		{
 			depthSize = 24;
 			stencilSize = 8;
@@ -5974,7 +5974,7 @@ FNA3D_Device* OPENGL_CreateDevice(
 		);
 
 		/* SPIR-V is very new and not really necessary. */
-		if (	(SDL_strcmp(renderer->shaderProfile, "glspirv") == 0) &&
+		if (	(SDL_strcasecmp(renderer->shaderProfile, "glspirv") == 0) &&
 			!renderer->useCoreProfile	)
 		{
 			renderer->shaderProfile = "glsl120";


### PR DESCRIPTION
Solves a lot of issue of user not realising values are case sensitive.
Mainly solves issues with FNA3D_FORCE_DRIVER and /gldevice:%s launch argument, aswell as FNA3D_OPENGL_WINDOW_DEPTHSTENCILFORMAT.
Changes SDL_strcmp to SDL_strcasecmp in FNA3D_PrepareWindowAttributes() and OPENGL_PrepareWindowAttributes()