### PR TITLE
[WIP] Refactor Vulkan's memory management into common code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(FNA3D
 	src/FNA3D_Driver_OpenGL_glfuncs.h
 	src/FNA3D_Driver_Vulkan_vkfuncs.h
 	src/FNA3D_PipelineCache.h
+	src/FNA3D_Memory.h
 	# Source Files
 	src/FNA3D.c
 	src/FNA3D_Driver_D3D11.c
@@ -99,6 +100,7 @@ add_library(FNA3D
 	src/FNA3D_Image.c
 	src/FNA3D_PipelineCache.c
 	src/FNA3D_Tracing.c
+	src/FNA3D_Memory.c
 )
 add_library(mojoshader STATIC
 	MojoShader/mojoshader.c

--- a/src/FNA3D_Memory.c
+++ b/src/FNA3D_Memory.c
@@ -1,0 +1,455 @@
+/* FNA3D - 3D Graphics Library for FNA
+ *
+ * Copyright (c) 2020-2023 Ethan Lee
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+
+#include "FNA3D_Memory.h"
+
+void FNA3D_Memory_MakeMemoryUnavailable(
+	FNA3D_Memory_MemoryAllocation *allocation
+) {
+	uint32_t i, j;
+	FNA3D_Memory_MemoryFreeRegion *freeRegion;
+
+	allocation->availableForAllocation = 0;
+
+	for (i = 0; i < allocation->freeRegionCount; i += 1)
+	{
+		freeRegion = allocation->freeRegions[i];
+
+		/* close the gap in the sorted list */
+		if (allocation->allocator->sortedFreeRegionCount > 1)
+		{
+			for (j = freeRegion->sortedIndex; j < allocation->allocator->sortedFreeRegionCount - 1; j += 1)
+			{
+				allocation->allocator->sortedFreeRegions[j] =
+					allocation->allocator->sortedFreeRegions[j + 1];
+
+				allocation->allocator->sortedFreeRegions[j]->sortedIndex = j;
+			}
+		}
+
+		allocation->allocator->sortedFreeRegionCount -= 1;
+	}
+}
+
+void FNA3D_Memory_RemoveMemoryFreeRegion(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemoryFreeRegion *freeRegion
+) {
+	uint32_t i;
+
+	SDL_LockMutex(context->allocatorLock);
+
+	if (freeRegion->allocation->availableForAllocation)
+	{
+		/* close the gap in the sorted list */
+		if (freeRegion->allocation->allocator->sortedFreeRegionCount > 1)
+		{
+			for (i = freeRegion->sortedIndex; i < freeRegion->allocation->allocator->sortedFreeRegionCount - 1; i += 1)
+			{
+				freeRegion->allocation->allocator->sortedFreeRegions[i] =
+					freeRegion->allocation->allocator->sortedFreeRegions[i + 1];
+
+				freeRegion->allocation->allocator->sortedFreeRegions[i]->sortedIndex = i;
+			}
+		}
+
+		freeRegion->allocation->allocator->sortedFreeRegionCount -= 1;
+	}
+
+	/* close the gap in the buffer list */
+	if (freeRegion->allocation->freeRegionCount > 1 && freeRegion->allocationIndex != freeRegion->allocation->freeRegionCount - 1)
+	{
+		freeRegion->allocation->freeRegions[freeRegion->allocationIndex] =
+			freeRegion->allocation->freeRegions[freeRegion->allocation->freeRegionCount - 1];
+
+		freeRegion->allocation->freeRegions[freeRegion->allocationIndex]->allocationIndex =
+			freeRegion->allocationIndex;
+	}
+
+	freeRegion->allocation->freeRegionCount -= 1;
+
+	freeRegion->allocation->freeSpace -= freeRegion->size;
+
+	SDL_free(freeRegion);
+
+	SDL_UnlockMutex(context->allocatorLock);
+}
+
+void FNA3D_Memory_NewMemoryFreeRegion(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemoryAllocation *allocation,
+	FNA3D_Memory_MemorySize offset,
+	FNA3D_Memory_MemorySize size
+) {
+	FNA3D_Memory_MemoryFreeRegion *newFreeRegion;
+	FNA3D_Memory_MemorySize newOffset, newSize;
+	int32_t insertionIndex = 0;
+	int32_t i;
+
+	SDL_LockMutex(context->allocatorLock);
+
+	/* look for an adjacent region to merge */
+	for (i = allocation->freeRegionCount - 1; i >= 0; i -= 1)
+	{
+		/* check left side */
+		if (allocation->freeRegions[i]->offset + allocation->freeRegions[i]->size == offset)
+		{
+			newOffset = allocation->freeRegions[i]->offset;
+			newSize = allocation->freeRegions[i]->size + size;
+
+			FNA3D_Memory_RemoveMemoryFreeRegion(context, allocation->freeRegions[i]);
+			FNA3D_Memory_NewMemoryFreeRegion(context, allocation, newOffset, newSize);
+
+			SDL_UnlockMutex(context->allocatorLock);
+			return;
+		}
+
+		/* check right side */
+		if (allocation->freeRegions[i]->offset == offset + size)
+		{
+			newOffset = offset;
+			newSize = allocation->freeRegions[i]->size + size;
+
+			FNA3D_Memory_RemoveMemoryFreeRegion(context, allocation->freeRegions[i]);
+			FNA3D_Memory_NewMemoryFreeRegion(context, allocation, newOffset, newSize);
+
+			SDL_UnlockMutex(context->allocatorLock);
+			return;
+		}
+	}
+
+	/* region is not contiguous with another free region, make a new one */
+	allocation->freeRegionCount += 1;
+	if (allocation->freeRegionCount > allocation->freeRegionCapacity)
+	{
+		allocation->freeRegionCapacity *= 2;
+		allocation->freeRegions = SDL_realloc(
+			allocation->freeRegions,
+			sizeof(FNA3D_Memory_MemoryFreeRegion*) * allocation->freeRegionCapacity
+		);
+	}
+
+	newFreeRegion = SDL_malloc(sizeof(FNA3D_Memory_MemoryFreeRegion));
+	newFreeRegion->offset = offset;
+	newFreeRegion->size = size;
+	newFreeRegion->allocation = allocation;
+
+	allocation->freeSpace += size;
+
+	allocation->freeRegions[allocation->freeRegionCount - 1] = newFreeRegion;
+	newFreeRegion->allocationIndex = allocation->freeRegionCount - 1;
+
+	if (allocation->availableForAllocation)
+	{
+		for (i = 0; i < allocation->allocator->sortedFreeRegionCount; i += 1)
+		{
+			if (allocation->allocator->sortedFreeRegions[i]->size < size)
+			{
+				/* this is where the new region should go */
+				break;
+			}
+
+			insertionIndex += 1;
+		}
+
+		if (allocation->allocator->sortedFreeRegionCount + 1 > allocation->allocator->sortedFreeRegionCapacity)
+		{
+			allocation->allocator->sortedFreeRegionCapacity *= 2;
+			allocation->allocator->sortedFreeRegions = SDL_realloc(
+				allocation->allocator->sortedFreeRegions,
+				sizeof(FNA3D_Memory_MemoryFreeRegion*) * allocation->allocator->sortedFreeRegionCapacity
+			);
+		}
+
+		/* perform insertion sort */
+		if (allocation->allocator->sortedFreeRegionCount > 0 && insertionIndex != allocation->allocator->sortedFreeRegionCount)
+		{
+			for (i = allocation->allocator->sortedFreeRegionCount; i > insertionIndex && i > 0; i -= 1)
+			{
+				allocation->allocator->sortedFreeRegions[i] = allocation->allocator->sortedFreeRegions[i - 1];
+				allocation->allocator->sortedFreeRegions[i]->sortedIndex = i;
+			}
+		}
+
+		allocation->allocator->sortedFreeRegionCount += 1;
+		allocation->allocator->sortedFreeRegions[insertionIndex] = newFreeRegion;
+		newFreeRegion->sortedIndex = insertionIndex;
+	}
+
+	SDL_UnlockMutex(context->allocatorLock);
+}
+
+FNA3D_Memory_MemoryUsedRegion* FNA3D_Memory_NewMemoryUsedRegion(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemoryAllocation *allocation,
+	FNA3D_Memory_MemorySize offset,
+	FNA3D_Memory_MemorySize size,
+	FNA3D_Memory_MemorySize resourceOffset,
+	FNA3D_Memory_MemorySize resourceSize,
+	FNA3D_Memory_MemorySize alignment
+) {
+	FNA3D_Memory_MemoryUsedRegion *memoryUsedRegion;
+
+	SDL_LockMutex(context->allocatorLock);
+
+	if (allocation->usedRegionCount == allocation->usedRegionCapacity)
+	{
+		allocation->usedRegionCapacity *= 2;
+		allocation->usedRegions = SDL_realloc(
+			allocation->usedRegions,
+			allocation->usedRegionCapacity * sizeof(FNA3D_Memory_MemoryUsedRegion*)
+		);
+	}
+
+	memoryUsedRegion = SDL_malloc(sizeof(FNA3D_Memory_MemoryUsedRegion));
+	memoryUsedRegion->allocation = allocation;
+	memoryUsedRegion->offset = offset;
+	memoryUsedRegion->size = size;
+	memoryUsedRegion->resourceOffset = resourceOffset;
+	memoryUsedRegion->resourceSize = resourceSize;
+	memoryUsedRegion->alignment = alignment;
+
+	allocation->usedSpace += size;
+
+	allocation->usedRegions[allocation->usedRegionCount] = memoryUsedRegion;
+	allocation->usedRegionCount += 1;
+
+	SDL_UnlockMutex(context->allocatorLock);
+
+	return memoryUsedRegion;
+}
+
+void FNA3D_Memory_RemoveMemoryUsedRegion(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemoryUsedRegion *usedRegion
+) {
+	uint32_t i;
+
+	SDL_LockMutex(context->allocatorLock);
+
+	for (i = 0; i < usedRegion->allocation->usedRegionCount; i += 1)
+	{
+		if (usedRegion->allocation->usedRegions[i] == usedRegion)
+		{
+			/* plug the hole */
+			if (i != usedRegion->allocation->usedRegionCount - 1)
+			{
+				usedRegion->allocation->usedRegions[i] = usedRegion->allocation->usedRegions[
+					usedRegion->allocation->usedRegionCount - 1
+				];
+			}
+
+			break;
+		}
+	}
+
+	usedRegion->allocation->usedSpace -= usedRegion->size;
+
+	usedRegion->allocation->usedRegionCount -= 1;
+
+	FNA3D_Memory_NewMemoryFreeRegion(
+		context,
+		usedRegion->allocation,
+		usedRegion->offset,
+		usedRegion->size
+	);
+
+	if (!usedRegion->allocation->dedicated)
+	{
+		context->needDefrag = 1;
+	}
+
+	SDL_free(usedRegion);
+
+	context->resourceFreed = 1;
+	SDL_UnlockMutex(context->allocatorLock);
+}
+
+void FNA3D_Memory_DeallocateMemory(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemorySubAllocator *allocator,
+	uint32_t allocationIndex
+) {
+	uint32_t i;
+
+	FNA3D_Memory_MemoryAllocation *allocation = allocator->allocations[allocationIndex];
+
+	SDL_LockMutex(context->allocatorLock);
+
+	for (i = 0; i < allocation->freeRegionCount; i += 1)
+	{
+		FNA3D_Memory_RemoveMemoryFreeRegion(
+			context,
+			allocation->freeRegions[i]
+		);
+	}
+	SDL_free(allocation->freeRegions);
+
+	/* no need to iterate used regions because deallocate
+	 * only happens when there are 0 used regions
+	 */
+	SDL_free(allocation->usedRegions);
+
+	context->freeMemoryFunc(context, allocation->memory);
+
+	SDL_DestroyMutex(allocation->mapLock);
+	SDL_free(allocation);
+
+	if (allocationIndex != allocator->allocationCount - 1)
+	{
+		allocator->allocations[allocationIndex] = allocator->allocations[allocator->allocationCount - 1];
+	}
+
+	allocator->allocationCount -= 1;
+
+	SDL_UnlockMutex(context->allocatorLock);
+}
+
+uint8_t FNA3D_Memory_AllocateMemory(
+	FNA3D_Memory_Context *context,
+	void* userdata,
+	uint32_t memoryTypeIndex,
+	FNA3D_Memory_MemorySize allocationSize,
+	uint8_t dedicated,
+	uint8_t isHostVisible,
+	FNA3D_Memory_MemoryAllocation **pMemoryAllocation
+) {
+	FNA3D_Memory_MemoryAllocation *allocation;
+	FNA3D_Memory_MemorySubAllocator *allocator = &context->memoryAllocator->subAllocators[memoryTypeIndex];
+	int64_t result;
+
+	allocation = SDL_malloc(sizeof(FNA3D_Memory_MemoryAllocation));
+	allocation->size = allocationSize;
+	allocation->freeSpace = 0; /* added by FreeRegions */
+	allocation->usedSpace = 0; /* added by UsedRegions */
+	allocation->mapLock = SDL_CreateMutex();
+
+	allocator->allocationCount += 1;
+	allocator->allocations = SDL_realloc(
+		allocator->allocations,
+		sizeof(FNA3D_Memory_MemoryAllocation*) * allocator->allocationCount
+	);
+
+	allocator->allocations[
+		allocator->allocationCount - 1
+	] = allocation;
+
+	if (dedicated)
+	{
+		allocation->dedicated = 1;
+		allocation->availableForAllocation = 0;
+	}
+	else
+	{
+		allocation->dedicated = 0;
+		allocation->availableForAllocation = 1;
+	}
+
+	allocation->usedRegions = SDL_malloc(sizeof(FNA3D_Memory_MemoryUsedRegion*));
+	allocation->usedRegionCount = 0;
+	allocation->usedRegionCapacity = 1;
+
+	allocation->freeRegions = SDL_malloc(sizeof(FNA3D_Memory_MemoryFreeRegion*));
+	allocation->freeRegionCount = 0;
+	allocation->freeRegionCapacity = 1;
+
+	allocation->allocator = allocator;
+
+	result = context->allocateMemoryFunc(
+		context,
+		userdata,
+		&allocation->memory
+	);
+
+	if (!result)
+	{
+		/* Uh oh, we couldn't allocate, time to clean up */
+		SDL_free(allocation->freeRegions);
+
+		allocator->allocationCount -= 1;
+		allocator->allocations = SDL_realloc(
+			allocator->allocations,
+			sizeof(FNA3D_Memory_MemoryAllocation*) * allocator->allocationCount
+		);
+
+		SDL_free(allocation);
+
+		return 0;
+	}
+
+	/* persistent mapping for host memory */
+	if (isHostVisible)
+	{
+		result = context->mapMemoryFunc(
+			context,
+			allocation
+		);
+
+		if (!result)
+		{
+			/* FIXME: How should we clean up here? */
+			return 0;
+		}
+	}
+	else
+	{
+		allocation->mapPointer = NULL;
+	}
+
+	FNA3D_Memory_NewMemoryFreeRegion(
+		context,
+		allocation,
+		0,
+		allocation->size
+	);
+
+	*pMemoryAllocation = allocation;
+	return 1;
+}
+
+uint8_t FNA3D_Memory_FindAllocationToDefragment(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemorySubAllocator *allocator,
+	uint32_t *allocationIndexToDefrag
+) {
+	uint32_t i, j;
+
+	for (i = 0; i < context->memoryAllocator->numSubAllocators; i += 1)
+	{
+		*allocator = context->memoryAllocator->subAllocators[i];
+
+		for (j = 0; j < allocator->allocationCount; j += 1)
+		{
+			if (allocator->allocations[j]->freeRegionCount > 1)
+			{
+				*allocationIndexToDefrag = j;
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}

--- a/src/FNA3D_Memory.h
+++ b/src/FNA3D_Memory.h
@@ -1,0 +1,201 @@
+/* FNA3D - 3D Graphics Library for FNA
+ *
+ * Copyright (c) 2020-2023 Ethan Lee
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+
+#ifndef FNA3D_MEMORY_H
+#define FNA3D_MEMORY_H
+
+#include <SDL.h>
+#include "FNA3D_Driver.h"
+
+/* Definitions */
+
+typedef uint64_t FNA3D_Memory_MemorySize;
+
+#define STARTING_ALLOCATION_SIZE 64000000 /* 64MB */
+#define ALLOCATION_INCREMENT 16000000 /* 16MB */
+#define MAX_ALLOCATION_SIZE 256000000 /* 256MB */
+#define FAST_TRANSFER_SIZE 64000000 /* 64MB */
+#define STARTING_TRANSFER_BUFFER_SIZE 8000000 /* 8MB */
+
+/* Utilities */
+
+static inline FNA3D_Memory_MemorySize FNA3D_Memory_NextHighestAlignment(
+	FNA3D_Memory_MemorySize n,
+	FNA3D_Memory_MemorySize align
+) {
+	return align * ((n + align - 1) / align);
+}
+
+/* Structs */
+
+typedef struct FNA3D_Memory_MemoryAllocation FNA3D_Memory_MemoryAllocation;
+
+typedef struct FNA3D_Memory_MemoryFreeRegion
+{
+	FNA3D_Memory_MemoryAllocation *allocation;
+	FNA3D_Memory_MemorySize offset;
+	FNA3D_Memory_MemorySize size;
+	uint32_t allocationIndex;
+	uint32_t sortedIndex;
+} FNA3D_Memory_MemoryFreeRegion;
+
+typedef struct FNA3D_Memory_MemoryUsedRegion
+{
+	FNA3D_Memory_MemoryAllocation *allocation;
+	FNA3D_Memory_MemorySize offset;
+	FNA3D_Memory_MemorySize size;
+	FNA3D_Memory_MemorySize resourceOffset; /* differs from offset based on alignment */
+	FNA3D_Memory_MemorySize resourceSize; /* differs from size based on alignment */
+	FNA3D_Memory_MemorySize alignment;
+	uint8_t isBuffer;
+	/* used to copy resource */
+	FNA3DNAMELESS union
+	{
+		FNA3D_Buffer *buffer;
+		FNA3D_Texture *texture;
+	};
+} FNA3D_Memory_MemoryUsedRegion;
+
+typedef struct FNA3D_Memory_MemorySubAllocator
+{
+	uint32_t memoryTypeIndex;
+	FNA3D_Memory_MemorySize nextAllocationSize;
+	FNA3D_Memory_MemoryAllocation **allocations;
+	uint32_t allocationCount;
+	FNA3D_Memory_MemoryFreeRegion **sortedFreeRegions;
+	uint32_t sortedFreeRegionCount;
+	uint32_t sortedFreeRegionCapacity;
+} FNA3D_Memory_MemorySubAllocator;
+
+struct FNA3D_Memory_MemoryAllocation
+{
+	FNA3D_Memory_MemorySubAllocator *allocator;
+	void* memory;
+	FNA3D_Memory_MemorySize size;
+	FNA3D_Memory_MemoryUsedRegion **usedRegions;
+	uint32_t usedRegionCount;
+	uint32_t usedRegionCapacity;
+	FNA3D_Memory_MemoryFreeRegion **freeRegions;
+	uint32_t freeRegionCount;
+	uint32_t freeRegionCapacity;
+	uint8_t dedicated;
+	uint8_t availableForAllocation;
+	FNA3D_Memory_MemorySize freeSpace;
+	FNA3D_Memory_MemorySize usedSpace;
+	uint8_t *mapPointer;
+	SDL_mutex *mapLock;
+};
+
+typedef struct FNA3D_Memory_MemoryAllocator
+{
+	FNA3D_Memory_MemorySubAllocator *subAllocators;
+	uint8_t numSubAllocators;
+} FNA3D_Memory_MemoryAllocator;
+
+typedef struct FNA3D_Memory_Context FNA3D_Memory_Context;
+
+typedef void (FNA3DCALL * FNA3D_Memory_FreeMemoryFunc)(FNA3D_Memory_Context *context, void* memory);
+typedef uint8_t (FNA3DCALL * FNA3D_Memory_AllocateMemoryFunc)(FNA3D_Memory_Context *context, void* userdata, void** allocation);
+typedef uint8_t (FNA3DCALL * FNA3D_Memory_MapMemoryFunc)(FNA3D_Memory_Context *context, FNA3D_Memory_MemoryAllocation *allocation);
+
+typedef struct FNA3D_Memory_Context
+{
+	FNA3D_Renderer *renderer;
+
+	uint8_t bufferDefragInProgress;
+	uint8_t needDefrag;
+	uint32_t defragTimer;
+	uint8_t resourceFreed;
+
+	FNA3D_Memory_MemoryAllocator *memoryAllocator;
+	SDL_mutex *allocatorLock;
+
+	/* Driver-specific callbacks */
+	FNA3D_Memory_FreeMemoryFunc freeMemoryFunc;
+	FNA3D_Memory_AllocateMemoryFunc allocateMemoryFunc;
+	FNA3D_Memory_MapMemoryFunc mapMemoryFunc;
+
+} FNA3D_Memory_Context;
+
+/* Functions */
+
+void FNA3D_Memory_MakeMemoryUnavailable(
+	FNA3D_Memory_MemoryAllocation *allocation
+);
+
+void FNA3D_Memory_RemoveMemoryFreeRegion(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemoryFreeRegion *freeRegion
+);
+
+void FNA3D_Memory_NewMemoryFreeRegion(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemoryAllocation *allocation,
+	FNA3D_Memory_MemorySize offset,
+	FNA3D_Memory_MemorySize size
+);
+
+FNA3D_Memory_MemoryUsedRegion* FNA3D_Memory_NewMemoryUsedRegion(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemoryAllocation *allocation,
+	FNA3D_Memory_MemorySize offset,
+	FNA3D_Memory_MemorySize size,
+	FNA3D_Memory_MemorySize resourceOffset,
+	FNA3D_Memory_MemorySize resourceSize,
+	FNA3D_Memory_MemorySize alignment
+);
+
+void FNA3D_Memory_RemoveMemoryUsedRegion(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemoryUsedRegion *usedRegion
+);
+
+void FNA3D_Memory_DeallocateMemory(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemorySubAllocator *allocator,
+	uint32_t allocationIndex
+);
+
+uint8_t FNA3D_Memory_AllocateMemory(
+	FNA3D_Memory_Context *context,
+	void* userdata,
+	uint32_t memoryTypeIndex,
+	FNA3D_Memory_MemorySize allocationSize,
+	uint8_t dedicated,
+	uint8_t isHostVisible,
+	FNA3D_Memory_MemoryAllocation **pMemoryAllocation
+);
+
+uint8_t FNA3D_Memory_FindAllocationToDefragment(
+	FNA3D_Memory_Context *context,
+	FNA3D_Memory_MemorySubAllocator *allocator,
+	uint32_t *allocationIndexToDefrag
+);
+
+#endif /* FNA3D_MEMORY_H */
+
+/* vim: set noexpandtab shiftwidth=8 tabstop=8: */
+

--- a/src/FNA3D_Memory.h
+++ b/src/FNA3D_Memory.h
@@ -32,7 +32,7 @@
 
 /* Definitions */
 
-typedef uint64_t FNA3D_Memory_MemorySize;
+typedef uint64_t FNA3D_Memory_Size;
 
 #define STARTING_ALLOCATION_SIZE 64000000 /* 64MB */
 #define ALLOCATION_INCREMENT 16000000 /* 16MB */
@@ -42,34 +42,34 @@ typedef uint64_t FNA3D_Memory_MemorySize;
 
 /* Utilities */
 
-static inline FNA3D_Memory_MemorySize FNA3D_Memory_NextHighestAlignment(
-	FNA3D_Memory_MemorySize n,
-	FNA3D_Memory_MemorySize align
+static inline FNA3D_Memory_Size FNA3D_Memory_NextHighestAlignment(
+	FNA3D_Memory_Size n,
+	FNA3D_Memory_Size align
 ) {
 	return align * ((n + align - 1) / align);
 }
 
 /* Structs */
 
-typedef struct FNA3D_Memory_MemoryAllocation FNA3D_Memory_MemoryAllocation;
+typedef struct FNA3D_Memory_Allocation FNA3D_Memory_Allocation;
 
-typedef struct FNA3D_Memory_MemoryFreeRegion
+typedef struct FNA3D_Memory_FreeRegion
 {
-	FNA3D_Memory_MemoryAllocation *allocation;
-	FNA3D_Memory_MemorySize offset;
-	FNA3D_Memory_MemorySize size;
+	FNA3D_Memory_Allocation *allocation;
+	FNA3D_Memory_Size offset;
+	FNA3D_Memory_Size size;
 	uint32_t allocationIndex;
 	uint32_t sortedIndex;
-} FNA3D_Memory_MemoryFreeRegion;
+} FNA3D_Memory_FreeRegion;
 
-typedef struct FNA3D_Memory_MemoryUsedRegion
+typedef struct FNA3D_Memory_UsedRegion
 {
-	FNA3D_Memory_MemoryAllocation *allocation;
-	FNA3D_Memory_MemorySize offset;
-	FNA3D_Memory_MemorySize size;
-	FNA3D_Memory_MemorySize resourceOffset; /* differs from offset based on alignment */
-	FNA3D_Memory_MemorySize resourceSize; /* differs from size based on alignment */
-	FNA3D_Memory_MemorySize alignment;
+	FNA3D_Memory_Allocation *allocation;
+	FNA3D_Memory_Size offset;
+	FNA3D_Memory_Size size;
+	FNA3D_Memory_Size resourceOffset; /* differs from offset based on alignment */
+	FNA3D_Memory_Size resourceSize; /* differs from size based on alignment */
+	FNA3D_Memory_Size alignment;
 	uint8_t isBuffer;
 	/* used to copy resource */
 	FNA3DNAMELESS union
@@ -77,48 +77,48 @@ typedef struct FNA3D_Memory_MemoryUsedRegion
 		FNA3D_Buffer *buffer;
 		FNA3D_Texture *texture;
 	};
-} FNA3D_Memory_MemoryUsedRegion;
+} FNA3D_Memory_UsedRegion;
 
-typedef struct FNA3D_Memory_MemorySubAllocator
+typedef struct FNA3D_Memory_SubAllocator
 {
 	uint32_t memoryTypeIndex;
-	FNA3D_Memory_MemorySize nextAllocationSize;
-	FNA3D_Memory_MemoryAllocation **allocations;
+	FNA3D_Memory_Size nextAllocationSize;
+	FNA3D_Memory_Allocation **allocations;
 	uint32_t allocationCount;
-	FNA3D_Memory_MemoryFreeRegion **sortedFreeRegions;
+	FNA3D_Memory_FreeRegion **sortedFreeRegions;
 	uint32_t sortedFreeRegionCount;
 	uint32_t sortedFreeRegionCapacity;
-} FNA3D_Memory_MemorySubAllocator;
+} FNA3D_Memory_SubAllocator;
 
-struct FNA3D_Memory_MemoryAllocation
+struct FNA3D_Memory_Allocation
 {
-	FNA3D_Memory_MemorySubAllocator *allocator;
+	FNA3D_Memory_SubAllocator *allocator;
 	void* memory;
-	FNA3D_Memory_MemorySize size;
-	FNA3D_Memory_MemoryUsedRegion **usedRegions;
+	FNA3D_Memory_Size size;
+	FNA3D_Memory_UsedRegion **usedRegions;
 	uint32_t usedRegionCount;
 	uint32_t usedRegionCapacity;
-	FNA3D_Memory_MemoryFreeRegion **freeRegions;
+	FNA3D_Memory_FreeRegion **freeRegions;
 	uint32_t freeRegionCount;
 	uint32_t freeRegionCapacity;
 	uint8_t dedicated;
 	uint8_t availableForAllocation;
-	FNA3D_Memory_MemorySize freeSpace;
-	FNA3D_Memory_MemorySize usedSpace;
+	FNA3D_Memory_Size freeSpace;
+	FNA3D_Memory_Size usedSpace;
 	uint8_t *mapPointer;
 	SDL_mutex *mapLock;
 };
 
 typedef struct FNA3D_Memory_MemoryAllocator
 {
-	FNA3D_Memory_MemorySubAllocator *subAllocators;
+	FNA3D_Memory_SubAllocator *subAllocators;
 	uint8_t numSubAllocators;
 } FNA3D_Memory_MemoryAllocator;
 
 typedef struct FNA3D_Memory_Properties
 {
-	FNA3D_Memory_MemorySize requiredSize;
-	FNA3D_Memory_MemorySize requiredAlignment;
+	FNA3D_Memory_Size requiredSize;
+	FNA3D_Memory_Size requiredAlignment;
 	uint32_t memoryTypeIndex;
 	uint8_t shouldAllocDedicated;
 	uint8_t isHostVisible;
@@ -129,11 +129,11 @@ typedef struct FNA3D_Memory_Context FNA3D_Memory_Context;
 
 typedef void (FNA3DCALL * FNA3D_Memory_FreeMemoryFunc)(FNA3D_Memory_Context *context, void* memory);
 typedef uint8_t (FNA3DCALL * FNA3D_Memory_AllocateMemoryFunc)(FNA3D_Memory_Context *context, void* userdata, void** pAllocation);
-typedef uint8_t (FNA3DCALL * FNA3D_Memory_MapMemoryFunc)(FNA3D_Memory_Context *context, FNA3D_Memory_MemoryAllocation *allocation);
+typedef uint8_t (FNA3DCALL * FNA3D_Memory_MapMemoryFunc)(FNA3D_Memory_Context *context, FNA3D_Memory_Allocation *allocation);
 typedef uint8_t (FNA3DCALL * FNA3D_Memory_FindBufferMemoryRequirementsFunc)(FNA3D_Memory_Context *context, void* nativeBuffer, uint8_t preferDeviceLocal, FNA3D_Memory_Properties *pMemoryProperties);
 typedef uint8_t (FNA3DCALL * FNA3D_Memory_FindTextureMemoryRequirementsFunc)(FNA3D_Memory_Context *context, void* nativeTexture, uint8_t preferDeviceLocal, FNA3D_Memory_Properties *pMemoryProperties);
-typedef uint8_t (FNA3DCALL * FNA3D_Memory_BindBufferMemoryFunc)(FNA3D_Memory_Context *context, FNA3D_Memory_MemoryUsedRegion *usedRegion, FNA3D_Memory_MemorySize alignedOffset, void* nativeBuffer);
-typedef uint8_t (FNA3DCALL * FNA3D_Memory_BindTextureMemoryFunc)(FNA3D_Memory_Context *context, FNA3D_Memory_MemoryUsedRegion *usedRegion, FNA3D_Memory_MemorySize alignedOffset, void* nativeTexture);
+typedef uint8_t (FNA3DCALL * FNA3D_Memory_BindBufferMemoryFunc)(FNA3D_Memory_Context *context, FNA3D_Memory_UsedRegion *usedRegion, FNA3D_Memory_Size alignedOffset, void* nativeBuffer);
+typedef uint8_t (FNA3DCALL * FNA3D_Memory_BindTextureMemoryFunc)(FNA3D_Memory_Context *context, FNA3D_Memory_UsedRegion *usedRegion, FNA3D_Memory_Size alignedOffset, void* nativeTexture);
 
 typedef struct FNA3D_Memory_Context
 {
@@ -144,6 +144,9 @@ typedef struct FNA3D_Memory_Context
 	uint32_t defragTimer;
 	uint8_t resourceFreed;
 
+	uint8_t unifiedMemoryWarning;
+	FNA3D_Memory_Size maxDeviceLocalHeapUsage;
+	FNA3D_Memory_Size deviceLocalHeapUsage;
 	FNA3D_Memory_MemoryAllocator *memoryAllocator;
 	SDL_mutex *allocatorLock;
 
@@ -161,17 +164,17 @@ typedef struct FNA3D_Memory_Context
 /* Functions */
 
 void FNA3D_Memory_MakeMemoryUnavailable(
-	FNA3D_Memory_MemoryAllocation *allocation
+	FNA3D_Memory_Allocation *allocation
 );
 
 void FNA3D_Memory_RemoveMemoryUsedRegion(
 	FNA3D_Memory_Context *context,
-	FNA3D_Memory_MemoryUsedRegion *usedRegion
+	FNA3D_Memory_UsedRegion *usedRegion
 );
 
 void FNA3D_Memory_DeallocateMemory(
 	FNA3D_Memory_Context *context,
-	FNA3D_Memory_MemorySubAllocator *allocator,
+	FNA3D_Memory_SubAllocator *allocator,
 	uint32_t allocationIndex
 );
 
@@ -179,32 +182,32 @@ uint8_t FNA3D_Memory_AllocateMemory(
 	FNA3D_Memory_Context *context,
 	void* userdata,
 	uint32_t memoryTypeIndex,
-	FNA3D_Memory_MemorySize allocationSize,
+	FNA3D_Memory_Size allocationSize,
 	uint8_t dedicated,
 	uint8_t isHostVisible,
-	FNA3D_Memory_MemoryAllocation **pMemoryAllocation
+	FNA3D_Memory_Allocation **pMemoryAllocation
 );
 
 uint8_t FNA3D_Memory_FindAllocationToDefragment(
 	FNA3D_Memory_Context *context,
-	FNA3D_Memory_MemorySubAllocator *allocator,
+	FNA3D_Memory_SubAllocator *allocator,
 	uint32_t *allocationIndexToDefrag
 );
 
 uint8_t FNA3D_Memory_BindMemoryForBuffer(
 	FNA3D_Memory_Context *context,
 	void* nativeBuffer,
-	FNA3D_Memory_MemorySize size,
+	FNA3D_Memory_Size size,
 	uint8_t preferDeviceLocal,
 	uint8_t isTransferBuffer,
-	FNA3D_Memory_MemoryUsedRegion **pMemoryUsedRegion
+	FNA3D_Memory_UsedRegion **pMemoryUsedRegion
 );
 
 uint8_t FNA3D_Memory_BindMemoryForTexture(
 	FNA3D_Memory_Context *context,
 	void* nativeTexture,
 	uint8_t isRenderTarget,
-	FNA3D_Memory_MemoryUsedRegion** usedRegion
+	FNA3D_Memory_UsedRegion** usedRegion
 );
 
 #endif /* FNA3D_MEMORY_H */

--- a/visualc/FNA3D.vcxproj
+++ b/visualc/FNA3D.vcxproj
@@ -112,6 +112,7 @@
     <ClCompile Include="..\src\FNA3D_Driver_Vulkan.c" />
     <ClCompile Include="..\src\FNA3D_Image.c" />
     <ClCompile Include="..\src\FNA3D_Driver_OpenGL.c" />
+    <ClCompile Include="..\src\FNA3D_Memory.c" />
     <ClCompile Include="..\src\FNA3D_PipelineCache.c" />
     <ClCompile Include="..\src\FNA3D_Tracing.c" />
   </ItemGroup>
@@ -123,6 +124,7 @@
     <ClInclude Include="..\src\FNA3D_Driver_OpenGL.h" />
     <ClInclude Include="..\src\FNA3D_Driver_OpenGL_glfuncs.h" />
     <ClInclude Include="..\src\FNA3D_Driver_Vulkan_vkfuncs.h" />
+    <ClInclude Include="..\src\FNA3D_Memory.h" />
     <ClInclude Include="..\src\FNA3D_PipelineCache.h" />
     <ClInclude Include="..\src\FNA3D_Tracing.h" />
   </ItemGroup>

--- a/visualc/FNA3D.vcxproj.filters
+++ b/visualc/FNA3D.vcxproj.filters
@@ -44,6 +44,7 @@
     </ClCompile>
     <ClCompile Include="..\src\FNA3D_Driver_Vulkan.c" />
     <ClCompile Include="..\src\FNA3D_Tracing.c" />
+    <ClCompile Include="..\src\FNA3D_Memory.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\FNA3D.h" />
@@ -55,6 +56,7 @@
     <ClInclude Include="..\src\FNA3D_Driver_D3D11.h" />
     <ClInclude Include="..\src\FNA3D_Driver_Vulkan_vkfuncs.h" />
     <ClInclude Include="..\src\FNA3D_Tracing.h" />
+    <ClInclude Include="..\src\FNA3D_Memory.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="mojoshader">


### PR DESCRIPTION
Once complete, this should help future backends (and SDL_GPU) wrangle memory management without having to copy-paste a bunch of logic from the Vulkan driver.

Rough Todo List:
- [ ] Resource memory binding
- [ ] Defrag
- [ ] Testing
- [ ] Less verbose naming?
- [ ] Other build systems (visualc-gdk, Xcode-iOS, etc)