### PR TITLE
Add SetEnv and GetEnv APIs for overriding FNA3D env vars at runtime

### DIFF
--- a/include/FNA3D.h
+++ b/include/FNA3D.h
@@ -493,6 +493,20 @@ FNA3DAPI void FNA3D_HookLogFunctions(
 	FNA3D_LogFunc error
 );
 
+/* Environment */
+
+/* Gets the value of an environment variable.
+ *
+ * Note that runtime changes to the process environment may not be returned unless set by FNA3D_SetEnv.
+ */
+FNA3DAPI const char* FNA3D_GetEnv(const char* name);
+
+/* Overwrites the value of an environment variable for FNA3D_GetEnv
+ *
+ * Note that this may be implemented as an 'overlay'. The underlying process environment may not be modified.
+ */
+FNA3DAPI void FNA3D_SetEnv(const char* name, const char* value);
+
 /* Init/Quit */
 
 /* Selects the most suitable graphics rendering backend for the system, then

--- a/src/FNA3D.c
+++ b/src/FNA3D.c
@@ -135,6 +135,19 @@ uint32_t FNA3D_LinkedVersion(void)
 	return FNA3D_COMPILED_VERSION;
 }
 
+
+/* Environment */
+
+const char* FNA3D_GetEnv(const char* name)
+{
+	return SDL_GetHint(name);
+}
+
+void FNA3D_SetEnv(const char* name, const char* value)
+{
+	SDL_SetHintWithPriority(name, value, SDL_HINT_OVERRIDE);
+}
+
 /* Driver Functions */
 
 static int32_t selectedDriver = -1;
@@ -143,7 +156,7 @@ uint32_t FNA3D_PrepareWindowAttributes(void)
 {
 	uint32_t result = 0;
 	uint32_t i;
-	const char *hint = SDL_GetHint("FNA3D_FORCE_DRIVER");
+	const char *hint = FNA3D_GetEnv("FNA3D_FORCE_DRIVER");
 	for (i = 0; drivers[i] != NULL; i += 1)
 	{
 		if (hint != NULL)

--- a/src/FNA3D_Driver_OpenGL.c
+++ b/src/FNA3D_Driver_OpenGL.c
@@ -5727,7 +5727,7 @@ static uint8_t OPENGL_PrepareWindowAttributes(uint32_t *flags)
 	/* Window depth format */
 	depthSize = 24;
 	stencilSize = 8;
-	depthFormatHint = SDL_GetHint("FNA3D_OPENGL_WINDOW_DEPTHSTENCILFORMAT");
+	depthFormatHint = FNA3D_GetEnv("FNA3D_OPENGL_WINDOW_DEPTHSTENCILFORMAT");
 	if (depthFormatHint != NULL)
 	{
 		if (SDL_strcasecmp(depthFormatHint, "None") == 0)
@@ -5969,7 +5969,7 @@ FNA3D_Device* OPENGL_CreateDevice(
 	LoadEntryPoints(renderer, driverInfo, debugMode);
 
 	/* Initialize shader context */
-	renderer->shaderProfile = SDL_GetHint("FNA3D_MOJOSHADER_PROFILE");
+	renderer->shaderProfile = FNA3D_GetEnv("FNA3D_MOJOSHADER_PROFILE");
 	if (renderer->shaderProfile == NULL || renderer->shaderProfile[0] == '\0')
 	{
 		renderer->shaderProfile = MOJOSHADER_glBestProfile(

--- a/src/FNA3D_Driver_Vulkan.c
+++ b/src/FNA3D_Driver_Vulkan.c
@@ -2528,7 +2528,7 @@ static uint8_t VULKAN_INTERNAL_DeterminePhysicalDevice(VulkanRenderer *renderer,
 		&renderer->memoryProperties
 	);
 
-	deviceLocalHeapUsageFactorStr = SDL_GetHint("FNA3D_VULKAN_DEVICE_LOCAL_HEAP_USAGE_FACTOR");
+	deviceLocalHeapUsageFactorStr = FNA3D_GetEnv("FNA3D_VULKAN_DEVICE_LOCAL_HEAP_USAGE_FACTOR");
 	if (deviceLocalHeapUsageFactorStr != NULL)
 	{
 		double factor = SDL_atof(deviceLocalHeapUsageFactorStr);
@@ -7267,7 +7267,7 @@ static void VULKAN_DestroyDevice(FNA3D_Device *device)
 
 	if (pipelineCacheResult == VK_SUCCESS)
 	{
-		pipelineCacheFileName = SDL_GetHint("FNA3D_VULKAN_PIPELINE_CACHE_FILE_NAME");
+		pipelineCacheFileName = FNA3D_GetEnv("FNA3D_VULKAN_PIPELINE_CACHE_FILE_NAME");
 		if (pipelineCacheFileName == NULL)
 		{
 			pipelineCacheFileName = DEFAULT_PIPELINE_CACHE_FILE_NAME;
@@ -11311,7 +11311,7 @@ static FNA3D_Device* VULKAN_CreateDevice(
 	pipelineCacheCreateInfo.pNext = NULL;
 	pipelineCacheCreateInfo.flags = 0;
 
-	pipelineCacheFileName = SDL_GetHint("FNA3D_VULKAN_PIPELINE_CACHE_FILE_NAME");
+	pipelineCacheFileName = FNA3D_GetEnv("FNA3D_VULKAN_PIPELINE_CACHE_FILE_NAME");
 	if (pipelineCacheFileName == NULL)
 	{
 		pipelineCacheFileName = DEFAULT_PIPELINE_CACHE_FILE_NAME;


### PR DESCRIPTION
Required for https://github.com/FNA-XNA/FNA/pull/437

### Discussion
- API naming
  - Use SDL `Hint` naming?
  - Full names? `Set/GetEnvironmentVariable`
  - Put `Override` in the name?
- Documentation quality
  - The use of 'may' to leave for implementation flexibility may (heh) cause confusion. COnsider simpler language which describes the current implementation rather than just the API surface.