### PR TITLE
Add support for using WARP software rasterizer with the D3D11 backend

### DIFF
--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -4848,8 +4848,7 @@ static uint8_t D3D11_PrepareWindowAttributes(uint32_t *flags)
 	};
 	HRESULT res;
 
-	const char* useWarp = SDL_GetHint("FNA3D_D3D11_USE_WARP");
-	const uint32_t driverType = (useWarp == NULL) || (SDL_strcmp(useWarp, "1") != 0)
+	const uint32_t driverType = SDL_GetHintBoolean("FNA3D_D3D11_USE_WARP", SDL_FALSE)
 		? D3D_DRIVER_TYPE_HARDWARE
 		: D3D_DRIVER_TYPE_WARP;
 
@@ -5115,8 +5114,7 @@ static FNA3D_Device* D3D11_CreateDevice(
 	int32_t i;
 	HRESULT res;
 
-	const char* useWarp = SDL_GetHint("FNA3D_D3D11_USE_WARP");
-	const uint32_t driverType = (useWarp == NULL) || (SDL_strcmp(useWarp, "1") != 0)
+	const uint32_t driverType = SDL_GetHintBoolean("FNA3D_D3D11_USE_WARP", SDL_FALSE)
 		? D3D_DRIVER_TYPE_UNKNOWN /* Must be UNKNOWN if adapter is non-null according to spec */
 		: D3D_DRIVER_TYPE_WARP;
 
@@ -5187,7 +5185,7 @@ try_create_device:
 	for (i = 0; i < 2; i += 1)
 	{
 		res = D3D11CreateDeviceFunc(
-			driverType == D3D_DRIVER_TYPE_WARP ? NULL : (IDXGIAdapter*) renderer->adapter,
+			(driverType == D3D_DRIVER_TYPE_WARP) ? NULL : (IDXGIAdapter*) renderer->adapter,
 			driverType, 
 			NULL,
 			flags,


### PR DESCRIPTION
by setting FNA3D_D3D11_USE_WARP=1

WARP software rasterizer ships with Windows and is fast enough on multicore machines to be useful as a debugging tool (to rule out driver issues, etc) or even as a manual fallback if the user has a bad GPU.

See https://learn.microsoft.com/en-us/windows/win32/direct3darticles/directx-warp and https://learn.microsoft.com/en-us/windows/win32/direct3d11/overviews-direct3d-11-devices-create-warp