### PR TITLE
Don't permanently leak render target readback staging buffers in D3D11

### DIFF
--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -3347,6 +3347,12 @@ static void D3D11_AddDisposeTexture(
 		}
 	}
 
+	if (tex->staging)
+	{
+		ID3D11Resource_Release(tex->staging);
+		tex->staging = NULL;
+	}
+
 	/* Release the shader resource view and texture */
 	ID3D11ShaderResourceView_Release(tex->shaderView);
 	IUnknown_Release(tex->handle);


### PR DESCRIPTION
Calling GetData on a RenderTarget2D was permanently leaking the temporary staging buffer. This took my functional test suite from ~800mb of memory usage to 5GB.