### PR TITLE
Fix changing swapchain format when flip model is enabled

### DIFF
--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -2789,16 +2789,21 @@ static void D3D11_INTERNAL_CreateBackbuffer(
 			{
 				/* Surface format changed, recreate entirely */
 				IDXGISwapChain_Release(swapchainData->swapchain);
-				/* 
-				  DXGI will crash in some cases if we don't flush deferred swapchain destruction:
-				  DXGI ERROR: IDXGIFactory::CreateSwapChain: Only one flip model swap chain can be associate with an HWND, 
-				   IWindow, or composition surface at a time. ClearState() and Flush() may need to be called on the D3D11 
-				   device context to trigger deferred destruction of old swapchains. [ MISCELLANEOUS ERROR #297: ]
-				*/
 
+				/* 
+				 * DXGI will crash in some cases if we don't flush deferred swapchain destruction:
+				 *
+				 * DXGI ERROR: IDXGIFactory::CreateSwapChain: Only one flip model swap chain can be
+				 * associate with an HWND, IWindow, or composition surface at a time. ClearState()
+				 * and Flush() may need to be called on the D3D11 device context to trigger deferred
+				 * destruction of old swapchains. [ MISCELLANEOUS ERROR #297: ]
+				 *
+				 * -kg
+				 */
 				ID3D11DeviceContext_ClearState(renderer->context);
 				ID3D11DeviceContext_Flush(renderer->context);
-				/* Purge shadow state. This sucks */
+
+				/* Purge shadow state. This sucks. -kg */
 				renderer->topology = -1;
 				renderer->indexBuffer = NULL;
 				memset(&renderer->viewport, 0, sizeof(FNA3D_Viewport));

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -2789,6 +2789,21 @@ static void D3D11_INTERNAL_CreateBackbuffer(
 			{
 				/* Surface format changed, recreate entirely */
 				IDXGISwapChain_Release(swapchainData->swapchain);
+				/* 
+				  DXGI will crash in some cases if we don't flush deferred swapchain destruction:
+				  DXGI ERROR: IDXGIFactory::CreateSwapChain: Only one flip model swap chain can be associate with an HWND, 
+				   IWindow, or composition surface at a time. ClearState() and Flush() may need to be called on the D3D11 
+				   device context to trigger deferred destruction of old swapchains. [ MISCELLANEOUS ERROR #297: ]
+				*/
+
+				ID3D11DeviceContext_ClearState(renderer->context);
+				ID3D11DeviceContext_Flush(renderer->context);
+				/* Purge shadow state. This sucks */
+				renderer->topology = -1;
+				renderer->indexBuffer = NULL;
+				memset(&renderer->viewport, 0, sizeof(FNA3D_Viewport));
+				memset(&renderer->scissorRect, 0, sizeof(FNA3D_Rect));
+
 				D3D11_INTERNAL_CreateSwapChain(
 					renderer,
 					parameters->backBufferFormat,


### PR DESCRIPTION
Changing backbuffer format with flip model enabled causes a crash right now.

```
Exception thrown at 0x00007FFD3C4D567C in HeavenLens.exe: Microsoft C++ exception: _com_error at memory location 0x000000AAA6BFD660. 
DXGI ERROR: IDXGIFactory::CreateSwapChain: Only one flip model swap chain can be associate with an HWND, IWindow, or composition surface at a time. ClearState() and Flush() may need to be called on the D3D11 device context to trigger deferred destruction of old swapchains. [ MISCELLANEOUS ERROR #297: ]
```