### PR TITLE
Vulkan: Adjust allocation strategy

### DIFF
--- a/src/FNA3D_CommandBuffer.h
+++ b/src/FNA3D_CommandBuffer.h
@@ -74,8 +74,7 @@ typedef struct FNA3D_CommandBufferDriver
 
 	FNA3D_BufferHandle* (*CreateTransferBuffer)(
 		FNA3D_Renderer *driverData,
-		size_t size,
-		uint8_t preferDeviceLocal
+		size_t size
 	);
 
 	void (*IncBufferRef)(


### PR DESCRIPTION
It turns out that copying to the BAR from the CPU is actually slow, so the concept of a "fast transfer buffer" was not correct in the first place. Getting rid of this streamlines the transfer logic, reduces VRAM usage, and may improve performance in texture upload bottleneck scenarios.

There's also no need to specify ignored memory properties - the driver is specific about what kind of memory types the GetMemoryRequirements functions return, so there's no need to constrict that further.

Additionally, setting the CACHED bit on buffer allocation is a massive speedup.