### PR TITLE
Rough fix for Texture.GetData being horribly slow on Vulkan backend

### DIFF
--- a/src/FNA3D_CommandBuffer.c
+++ b/src/FNA3D_CommandBuffer.c
@@ -725,7 +725,8 @@ void FNA3D_CommandBuffer_MarkBufferAsBound(
 FNA3D_TransferBuffer* FNA3D_CommandBuffer_AcquireTransferBuffer(
 	FNA3D_CommandBufferManager *manager,
 	size_t requiredSize,
-	size_t alignment
+	size_t alignment,
+	uint8_t allowFastTransferBuffer
 ) {
 	FNA3D_TransferBuffer *transferBuffer;
 	size_t parentBufferSize;
@@ -765,7 +766,8 @@ FNA3D_TransferBuffer* FNA3D_CommandBuffer_AcquireTransferBuffer(
 	}
 
 	/* Is the fast transfer buffer available? */
-	if (	manager->transferBufferPool.fastTransferBufferAvailable &&
+	if (	allowFastTransferBuffer &&
+		manager->transferBufferPool.fastTransferBufferAvailable &&
 		requiredSize < FAST_TRANSFER_SIZE	)
 	{
 		transferBuffer = manager->transferBufferPool.fastTransferBuffer;

--- a/src/FNA3D_CommandBuffer.h
+++ b/src/FNA3D_CommandBuffer.h
@@ -198,7 +198,8 @@ FNA3D_SHAREDINTERNAL void FNA3D_CommandBuffer_MarkBufferAsBound(
 FNA3D_SHAREDINTERNAL FNA3D_TransferBuffer* FNA3D_CommandBuffer_AcquireTransferBuffer(
 	FNA3D_CommandBufferManager *manager,
 	size_t requiredSize,
-	size_t alignment
+	size_t alignment,
+	uint8_t allowFastTransferBuffer
 );
 
 FNA3D_SHAREDINTERNAL void FNA3D_CommandBuffer_ClearDestroyedBuffer(


### PR DESCRIPTION
Feedback welcome on how this should actually be fixed. Looking into why GetData is really slow on Vulkan, I think I found a few things:

* GetData does a synced flush which waits for the whole device to become idle. I'm not certain whether this was causing measurable slowdown, but waiting for the device to be fully idle seems wrong and unnecessary.
* SubmitCommands for vulkan does present-related work even when present isn't set.
* If present isn't set, SubmitCommands seems to not actually wait for the in-flight fence of the command buffer it just submitted, which doesn't seem like what we want.
* All the transfer buffers are allocated using the combination of HOST_VISIBLE and HOST_COHERENT, which based on vulkan documentation is the slowest type of memory. This appears to cause the SDL_memcpy in the readback operation to be incredibly slow - presumably every single read is doing an individual DMA from GPU memory. I think what we want is HOST_VISIBLE and HOST_CACHED, plus potentially some manual flushing of regions we just touched.
![image](https://github.com/FNA-XNA/FNA3D/assets/198130/ebab7a0c-fc99-4142-9245-fda6eff0b2a3)
* Readback potentially uses the fast transfer buffer, which is allocated with preferDeviceLocal=1. For readback, I think we want one of the non-device-local slow transfer buffers, since if I understand this right the GPU will do a big DMA to copy the buffer contents over to CPU-managed memory?

The fixes I tried to apply here:
* When acquiring a transfer buffer for GetData, ensure we don't use the fast transfer buffer. Leave that one for uploads.
* When binding buffer memory, always ask for HOST_CACHED, not HOST_COHERENT. I didn't have to add any explicit flushes anywhere for uploads to still work.
* Only do some of the swapchain-related work if present!=0 in SubmitCommands.
* In SubmitCommands, if present==0, wait for the inFlightFence of the command buffer we just submitted, so that the copy is done by the time GetTextureData wants the data.
* Do a non-sync flush in GetTextureData, since we don't need to wait for the device to be idle, we just need to wait for the copy to finish.

My game is doing one small (320x180x8bpp) GetData per frame at the very start before any drawing happens, on a render target from the previous frame. Without these fixes, D3D11 gets around 1150fps and Vulkan gets ~45fps. With these fixes Vulkan gets ~950fps.