### PR TITLE
Better diagnostics when an SDL_GPU backend fails to initialize

### DIFF
--- a/src/FNA3D_Driver_SDL.c
+++ b/src/FNA3D_Driver_SDL.c
@@ -4026,7 +4026,13 @@ static void SDLGPU_DestroyDevice(FNA3D_Device *device)
 
 static uint8_t SDLGPU_PrepareWindowAttributes(uint32_t *flags)
 {
-	return SDL_GPUSupportsShaderFormats(MOJOSHADER_sdlGetShaderFormats(), NULL);
+	uint8_t result = SDL_GPUSupportsShaderFormats(MOJOSHADER_sdlGetShaderFormats(), NULL);
+	const char* error = SDL_GetError();
+	if (error)
+	{
+		FNA3D_LogWarn("SDL_GPUSupportsShaderFormats failed: %s", error);
+	}
+	return result;
 }
 
 static FNA3D_Device* SDLGPU_CreateDevice(
@@ -4057,7 +4063,7 @@ static FNA3D_Device* SDLGPU_CreateDevice(
 
 	if (device == NULL)
 	{
-		FNA3D_LogError("Failed to create SDLGPU device!");
+		FNA3D_LogError("Failed to create SDLGPU device: %s", SDL_GetError());
 		return NULL;
 	}
 

--- a/src/FNA3D_Driver_SDL.c
+++ b/src/FNA3D_Driver_SDL.c
@@ -4027,10 +4027,9 @@ static void SDLGPU_DestroyDevice(FNA3D_Device *device)
 static uint8_t SDLGPU_PrepareWindowAttributes(uint32_t *flags)
 {
 	uint8_t result = SDL_GPUSupportsShaderFormats(MOJOSHADER_sdlGetShaderFormats(), NULL);
-	const char* error = SDL_GetError();
-	if (error)
+	if (!result)
 	{
-		FNA3D_LogWarn("SDL_GPUSupportsShaderFormats failed: %s", error);
+		FNA3D_LogWarn("SDL_GPUSupportsShaderFormats failed: %s", SDL_GetError());
 	}
 	return result;
 }


### PR DESCRIPTION
Right now if an SDL_GPU backend fails to initialize for any reason you don't get any diagnostic feedback. This should fix that for all the scenarios I can think of.