### PR TITLE
make upload command buffer operations thread-safe

### DIFF
--- a/src/FNA3D_Driver_SDL.c
+++ b/src/FNA3D_Driver_SDL.c
@@ -1046,15 +1046,14 @@ static void SDLGPU_SwapBuffers(
 	void* overrideWindowHandle
 ) {
 	SDLGPU_Renderer *renderer = (SDLGPU_Renderer*) driverData;
-	SDL_LockMutex(renderer->copyPassMutex);
-
-	SDLGPU_INTERNAL_EndCopyPass(renderer);
-	SDLGPU_INTERNAL_EndRenderPass(renderer);
-
 	SDL_GPUTexture *swapchainTexture;
 	SDL_GPUBlitInfo blitInfo;
 	uint32_t width, height;
 	uint32_t i;
+
+	SDL_LockMutex(renderer->copyPassMutex);
+	SDLGPU_INTERNAL_EndCopyPass(renderer);
+	SDLGPU_INTERNAL_EndRenderPass(renderer);
 
 	if (renderer->fenceGroups[renderer->frameCounter][0] != NULL)
 	{


### PR DESCRIPTION
this PR resolves a compatibility issue where projects that use threading for GPU copy operations would sometimes crash due to thread contention when using the SDLGPU driver. the contended resources were the upload and render command buffers and associated copy/render passes, and corresponding metadata.

this PR resolves the issue with the following approach:
- gate copy pass access and associated metadata behind a corresponding copy pass mutex
  - adding upload commands to the copy pass locks the mutex until the command is added and metadata is updated
  - mutex is locked when the upload command buffer is submitted; new command buffer is acquired and copy pass begun before mutex is unlocked
- in copy pass-exclusive methods (e.g. SetTextureData), when a command flush is required, only flush the upload command buffer so as to avoid interfering with the render command buffer.
- always flush the upload command buffer before any render command buffer submissions (and lock the mutex)
- no mutex for render command buffer access; assume that all render ops are scheduled and run by the main thread only

to test this implementation, i ran the following ruby script:

<details>
<summary>n_test.rb</summary>

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

require 'open3'

n = ARGV[0].to_i
puts "running startup #{n} times"

env = { 'FNA_PLATFORM_BACKEND' => 'SDL3', 'FNA3D_FORCE_DRIVER' => 'SDLGPU' }

n.times do |index|
  puts "attempt #{index + 1}"
  Open3.popen3(env, './Celeste') do |_, output, error, t|
    while (line = output.gets)
      next unless line.include?('DONE LOADING')

      puts('success')
      Process.kill('TERM', t.pid)
    end

    unless t.value.success?
      puts "failed to load assets on attempt #{index + 1}"
      puts error.read
      Process.kill('KILL', t.pid)
      exit 1
    end
  end
end
```
</details>

the script opens *Celeste* and waits for it to print `DONE LOADING` on stdout, kills the program and does it again, n times. if the program encounters an error it prints stderr and exits.

initially, i ran this against an FNA3D build from the current `master` branch. *Celeste* crashed on startup roughly 10% of the time with expected errors (e.g. "Command buffer already submitted!", "Cannot acquire a swapchain texture during a pass!"). with an FNA3D build from this PR, i ran this script with n=500 without any failures.

submitting as a draft because i would like to see a successful test against another FNA game known to use threaded uploads at startup. i am working on testing TMNT but it requires a new dev environment (no mac builds), so assistance would be appreciated. please note that the script above is hard-coded to work with *Celeste* only as it depends on the specific `DONE LOADING` stdout line that i am pretty sure originates from the *Celeste* codebase.