### PR TITLE
Implement SysTexture for SDL_GPU backend

### DIFF
--- a/include/FNA3D_SysRenderer.h
+++ b/include/FNA3D_SysRenderer.h
@@ -86,6 +86,20 @@ typedef struct FNA3D_SysRendererEXT
 			uint32_t queueFamilyIndex;
 		} vulkan;
 #endif /* FNA3D_DRIVER_VULKAN */
+#if FNA3D_DRIVER_SDL
+		struct
+		{
+			// FIXME: This definition is incomplete! -kg
+			SDL_GPUDevice *device;
+			// Reserved pointers to create space for things we need to expose later, for compatibility
+			void *reserved1,
+				*reserved2,
+				*reserved3,
+				*reserved4,
+				*reserved5,
+				*reserved6;
+		} sdl;
+#endif
 		uint8_t filler[64];
 	} renderer;
 } FNA3D_SysRendererEXT;
@@ -131,6 +145,13 @@ typedef struct FNA3D_SysTextureEXT
 			FNA3D_VULKAN_HANDLE_TYPE view;	/* VkImageView */
 		} vulkan;
 #endif /* FNA3D_DRIVER_VULKAN */
+#if FNA3D_DRIVER_SDL
+		struct
+		{
+			void /* SDL_GPUTexture */ *texture;
+			void /* SDL_GPUTextureCreateInfo */ *createInfo;
+		} sdl;
+#endif
 		uint8_t filler[64];
 	} texture;
 } FNA3D_SysTextureEXT;

--- a/src/FNA3D_Driver_SDL.c
+++ b/src/FNA3D_Driver_SDL.c
@@ -4043,10 +4043,8 @@ static void SDLGPU_DestroyDevice(FNA3D_Device *device)
 
 	SDLGPU_INTERNAL_FlushCommands(renderer);
 	// avoid command buffer leaks by explicitly canceling newly-acquired command buffers
-	/*
 	SDL_CancelGPUCommandBuffer(renderer->uploadCommandBuffer);
 	SDL_CancelGPUCommandBuffer(renderer->renderCommandBuffer);
-	*/
 	SDL_WaitForGPUIdle(renderer->device);
 
 	SDL_UnlockMutex(renderer->copyPassMutex);


### PR DESCRIPTION
I've tested this locally by using it to create R16_UNORM textures for my dav1dfile test and it worked (with a paired change to FNA to allow me to create a Texture2D instance around a SysTexture handle.)