### PR TITLE
Fix sRGB backbuffers on the SDL_GPU and D3D11 backends

### DIFF
--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -2717,6 +2717,8 @@ static void D3D11_INTERNAL_CreateSwapChain(
 				colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
 			}
 			IDXGISwapChain3_SetColorSpace1(swapchain3, colorSpace);
+
+			IDXGISwapChain_Release(swapchain);
 		}
 	}
 

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -2602,7 +2602,9 @@ static void D3D11_INTERNAL_CreateSwapChain(
 		swapchainDesc.BufferDesc.Format = XNAToD3D_TextureFormat[FNA3D_SURFACEFORMAT_COLOR];
 	}
 	else
+	{
 		swapchainDesc.BufferDesc.Format = XNAToD3D_TextureFormat[backBufferFormat];
+	}
 	swapchainDesc.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
 	swapchainDesc.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
 

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -2598,6 +2598,7 @@ static void D3D11_INTERNAL_CreateSwapChain(
 	swapchainDesc.BufferDesc.RefreshRate.Denominator = 0;
 	if (backBufferFormat == FNA3D_SURFACEFORMAT_COLORSRGB_EXT)
 	{
+		/* The swapchain RTV uses BGRA8_UNORM but with an SDR Linear colorspace */
 		sRGB = 1;
 		swapchainDesc.BufferDesc.Format = XNAToD3D_TextureFormat[FNA3D_SURFACEFORMAT_COLOR];
 	}

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -2571,6 +2571,7 @@ static void D3D11_INTERNAL_CreateSwapChain(
 	DXGI_COLOR_SPACE_TYPE colorSpace;
 	HRESULT res;
 
+	uint8_t sRGB = 0;
 	uint8_t growSwapchains = (swapchainData == NULL);
 
 #ifdef FNA3D_DXVK_NATIVE
@@ -2595,7 +2596,13 @@ static void D3D11_INTERNAL_CreateSwapChain(
 	swapchainDesc.BufferDesc.Height = 0;
 	swapchainDesc.BufferDesc.RefreshRate.Numerator = 0;
 	swapchainDesc.BufferDesc.RefreshRate.Denominator = 0;
-	swapchainDesc.BufferDesc.Format = XNAToD3D_TextureFormat[backBufferFormat];
+	if (backBufferFormat == FNA3D_SURFACEFORMAT_COLORSRGB_EXT)
+	{
+		sRGB = 1;
+		swapchainDesc.BufferDesc.Format = XNAToD3D_TextureFormat[FNA3D_SURFACEFORMAT_COLOR];
+	}
+	else
+		swapchainDesc.BufferDesc.Format = XNAToD3D_TextureFormat[backBufferFormat];
 	swapchainDesc.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
 	swapchainDesc.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
 
@@ -2683,7 +2690,7 @@ static void D3D11_INTERNAL_CreateSwapChain(
 	}
 
 	/* Set colorspace, if applicable */
-	if (SDL_GetHintBoolean("FNA3D_ENABLE_HDR_COLORSPACE", SDL_FALSE))
+	if (SDL_GetHintBoolean("FNA3D_ENABLE_HDR_COLORSPACE", SDL_FALSE) || sRGB)
 	{
 		if (SUCCEEDED(IDXGISwapChain_QueryInterface(
 			swapchain,
@@ -2698,6 +2705,10 @@ static void D3D11_INTERNAL_CreateSwapChain(
 					backBufferFormat == FNA3D_SURFACEFORMAT_HDRBLENDABLE	)
 			{
 				colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709;
+			}
+			else if (sRGB)
+			{
+				colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
 			}
 			else
 			{

--- a/src/FNA3D_Driver_D3D11.c
+++ b/src/FNA3D_Driver_D3D11.c
@@ -2709,10 +2709,6 @@ static void D3D11_INTERNAL_CreateSwapChain(
 			{
 				colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709;
 			}
-			else if (sRGB)
-			{
-				colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
-			}
 			else
 			{
 				colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;

--- a/src/FNA3D_Driver_SDL.c
+++ b/src/FNA3D_Driver_SDL.c
@@ -2651,7 +2651,9 @@ static void SDLGPU_ResetBackbuffer(
 		presentationParameters
 	);
 
-	swapchainComposition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
+	swapchainComposition = (presentationParameters->backBufferFormat == FNA3D_SURFACEFORMAT_COLORSRGB_EXT)
+		? SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR
+		: SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
 
 	if (SDL_GetHintBoolean("FNA3D_ENABLE_HDR_COLORSPACE", false))
 	{


### PR DESCRIPTION
sRGB textures and render targets work but when you request a sRGB backbuffer, you don't get one right now.

On SDL_GPU we aren't flowing the sRGB flag through.

On D3D11, we changed to flip model which doesn't allow sRGB backbuffers, you have to set the colorspace on the swapchain instead.

This PR also fixes a swapchain leak triggered by enabling HDR in D3D11