### PR TITLE
Use Debug FNA3D for PowerPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,21 +90,15 @@ jobs:
       run: cmake -B debug -G Ninja . -DCMAKE_BUILD_TYPE=Debug -DSDL3_DIR=${GITHUB_WORKSPACE}/SDL/debug
 
     - name: Build (Debug)
-      run: ninja -C debug
-
-    - name: CMake configure (Release)
-      run: cmake -B release -G Ninja . -DCMAKE_BUILD_TYPE=Release -DSDL3_DIR=${GITHUB_WORKSPACE}/SDL/debug
-
-    - name: Build (Release)
       run: |
-        ninja -C release
-        chrpath -d release/libFNA3D.so.0
+        ninja -C debug
+        chrpath -d debug/libFNA3D.so.0
 
     - name: Archive build result
       uses: actions/upload-artifact@v4
       with:
         name: FNA3D-libpowerpc
-        path: release/libFNA3D.so.0
+        path: debug/libFNA3D.so.0
 
   linux-mingw:
     name: Fedora Linux MinGW

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         ninja -C debug
         # Temporary, remove when Release builds work
         chrpath -d debug/libFNA3D.so.0
-        strip -S debug/libFNA3D.so.0
+        powerpc-linux-gnu-strip -S debug/libFNA3D.so.0
 
     - name: CMake configure (Release)
       run: cmake -B release -G Ninja . -DCMAKE_BUILD_TYPE=Release -DSDL3_DIR=${GITHUB_WORKSPACE}/SDL/debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     #  run: |
     #    ninja -C release
     #    chrpath -d release/libFNA3D.so.0
-    #    strip -S release/libFNA3D.so.0
+    #    powerpc-unknown-linux-gnu-strip -S release/libFNA3D.so.0
         
     - name: Archive build result
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,24 @@ jobs:
     - name: Build (Debug)
       run: |
         ninja -C debug
+        # Temporary, remove when Release builds work
         chrpath -d debug/libFNA3D.so.0
+        strip -S debug/libFNA3D.so.0
 
+    - name: CMake configure (Release)
+      run: cmake -B release -G Ninja . -DCMAKE_BUILD_TYPE=Release -DSDL3_DIR=${GITHUB_WORKSPACE}/SDL/debug
+
+    #- name: Build (Release)
+    #  run: |
+    #    ninja -C release
+    #    chrpath -d release/libFNA3D.so.0
+    #    strip -S release/libFNA3D.so.0
+        
     - name: Archive build result
       uses: actions/upload-artifact@v4
       with:
         name: FNA3D-libpowerpc
+    #    path: release/libFNA3D.so.0 # Fails to compile shaders
         path: debug/libFNA3D.so.0
 
   linux-mingw:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         ninja -C debug
         # Temporary, remove when Release builds work
         chrpath -d debug/libFNA3D.so.0
-        powerpc-linux-gnu-strip -S debug/libFNA3D.so.0
+        powerpc-unknown-linux-gnu-strip -S debug/libFNA3D.so.0
 
     - name: CMake configure (Release)
       run: cmake -B release -G Ninja . -DCMAKE_BUILD_TYPE=Release -DSDL3_DIR=${GITHUB_WORKSPACE}/SDL/debug


### PR DESCRIPTION
For some reason I haven't figured out, MojoShader can only realize when a Effect file is valid on Big Endian if FNA3D is built as Debug.