### PR TITLE
Fix "Format is not compatible with alpha-to-coverage"

### DIFF
--- a/src/FNA3D_Driver_SDL.c
+++ b/src/FNA3D_Driver_SDL.c
@@ -1557,6 +1557,7 @@ static SDL_GPUGraphicsPipeline* SDLGPU_INTERNAL_FetchGraphicsPipeline(
 	/* Multisample */
 
 	createInfo.multisample_state.sample_count = renderer->nextRenderPassMultisampleCount;
+	createInfo.multisample_state.enable_alpha_to_coverage = false;
 	if (renderer->multisampleMask != 0xFFFFFFFF)
 	{
 		createInfo.multisample_state.enable_mask = true;


### PR DESCRIPTION
Speculative fix. Haven't tested this locally yet, it was easier to just edit it on github