### PR TITLE
Detect multithreaded use of common FNA3D operations with the SDL_GPU backend and assert in debug builds

### DIFF
--- a/src/FNA3D_Driver_SDL.c
+++ b/src/FNA3D_Driver_SDL.c
@@ -4347,7 +4347,9 @@ static FNA3D_Device* SDLGPU_CreateDevice(
 	renderer = SDL_malloc(sizeof(SDLGPU_Renderer));
 	SDL_memset(renderer, '\0', sizeof(SDLGPU_Renderer));
 
+#ifndef NDEBUG
 	renderer->ownerThreadID = SDL_GetCurrentThreadID();
+#endif
 	renderer->device = device;
 	renderer->copyPassMutex = SDL_CreateMutex();
 


### PR DESCRIPTION
Idea came up on discord. It's not safe to do multithreaded operations on the SDL_GPU backend even though it's guarded by a mutex (the explanation for why not is complicated and I've partially forgotten) so ideally anyone having trouble can run with a debug build of FNA3D and the asserts will help them spot the bug in their code.