### PR TITLE
OpenGL: recognize WebGL's WEBGL_compressed_texture_s3tc extension

### DIFF
--- a/src/FNA3D_Driver_OpenGL.c
+++ b/src/FNA3D_Driver_OpenGL.c
@@ -5755,7 +5755,13 @@ static inline void CheckExtensions(
 		SDL_strstr(ext, "GL_EXT_texture_compression_s3tc") ||
 		SDL_strstr(ext, "GL_OES_texture_compression_S3TC") ||
 		SDL_strstr(ext, "GL_EXT_texture_compression_dxt3") ||
-		SDL_strstr(ext, "GL_EXT_texture_compression_dxt5")
+		SDL_strstr(ext, "GL_EXT_texture_compression_dxt5") ||
+		/* WebGL (emscripten) exposes S3TC/DXT only under this WebGL-specific
+		 * extension name, not any of the GL_* aliases above. Without matching it
+		 * FNA3D reports S3TC unsupported on WebGL targets, so DXT textures fall
+		 * back to Texture2DReader's CPU decompression path instead of being
+		 * uploaded as compressed data. */
+		SDL_strstr(ext, "WEBGL_compressed_texture_s3tc")
 	);
 	uint8_t bc7 = (
 		SDL_strstr(ext, "GL_ARB_texture_compression_bptc") != NULL


### PR DESCRIPTION
### Problem

On WebGL targets (emscripten), `CheckExtensions` in the OpenGL driver never sets `s3tc = 1`, even when the browser fully supports DXT/S3TC on the GPU.

The reason is naming: WebGL exposes S3TC support **only** under the WebGL-specific extension string `WEBGL_compressed_texture_s3tc`. It does not report any of the desktop/GLES aliases the driver currently checks (`GL_EXT_texture_compression_s3tc`, `GL_OES_texture_compression_S3TC`, `GL_EXT_texture_compression_dxt3/5`).

With `s3tc = 0`, DXT-compressed textures are routed through `Texture2DReader`'s CPU decompression path instead of being uploaded as compressed data — slower, and in practice it produced incorrect (black) output for DXT content in a wasm/WebGL build.

### Fix

Add `WEBGL_compressed_texture_s3tc` to the `s3tc` extension check in `CheckExtensions`. One extra `SDL_strstr`, no behavioral change on any non-WebGL platform (the string never appears in a desktop/GLES extension list).

### Testing

Built for wasm (emscripten, threaded, WebGL2) and confirmed on a real GPU (ANGLE/D3D11) that with this change DXT block/terrain atlases upload via `glCompressedTexImage2D` and render correctly, where before they were CPU-decompressed and rendered black.